### PR TITLE
feat: 판매자(Seller) 도메인 구현 및 자동 승인 스케줄러 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 application.yml
 secret.yml
 **/src/main/generated
+
+# application.yml
+application.yml

--- a/src/main/java/com/example/dropshop/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/example/dropshop/domain/seller/controller/SellerController.java
@@ -1,0 +1,34 @@
+package com.example.dropshop.domain.seller.controller;
+
+import com.example.dropshop.domain.seller.dto.request.SellerApplyRequest;
+import com.example.dropshop.domain.seller.dto.response.SellerResponse;
+import com.example.dropshop.domain.seller.service.SellerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails; // 표준 인터페이스
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/sellers")
+@RequiredArgsConstructor
+public class SellerController {
+
+    private final SellerService sellerService;
+
+    @PostMapping("/apply")
+    public ResponseEntity<SellerResponse> applySeller(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody SellerApplyRequest request) {
+
+        // userDetails.getUsername()은 보통 로그인 시 사용한 이메일입니다.
+        return ResponseEntity.ok(sellerService.applySeller(userDetails.getUsername(), request));
+    }
+
+    @GetMapping("/me/status")
+    public ResponseEntity<SellerResponse> getMyStatus(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(sellerService.getMySellerStatus(userDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerApplyRequest.java
+++ b/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerApplyRequest.java
@@ -1,0 +1,22 @@
+package com.example.dropshop.domain.seller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SellerApplyRequest {
+    @NotBlank(message = "사업자 번호는 필수입니다.")
+    @Pattern(regexp = "\\d{10}", message = "사업자 번호는 10자리 숫자여야 합니다.")
+    private String businessNo;
+
+    @NotBlank(message = "브랜드 이름은 필수입니다.")
+    private String brandName;
+
+    private String brandLogo;
+
+    @NotBlank(message = "정산 계좌 정보는 필수입니다.")
+    private String accountInfo;
+}

--- a/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.dropshop.domain.seller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SellerUpdateRequest {
+    @NotBlank(message = "브랜드 이름은 필수입니다.")
+    private String brandName;
+
+    private String brandLogo;
+
+    @NotBlank(message = "정산 계좌 정보는 필수입니다.")
+    private String accountInfo;
+}

--- a/src/main/java/com/example/dropshop/domain/seller/dto/response/SellerResponse.java
+++ b/src/main/java/com/example/dropshop/domain/seller/dto/response/SellerResponse.java
@@ -1,0 +1,21 @@
+package com.example.dropshop.domain.seller.dto.response;
+
+import com.example.dropshop.domain.seller.entity.Seller;
+import lombok.Getter;
+
+@Getter
+public class SellerResponse {
+    private final Long id;
+    private final String businessNo;
+    private final String brandName;
+    private final String brandLogo;
+    private final com.example.dropshop.domain.seller.enums.SellerStatus status;
+
+    public SellerResponse(Seller seller) {
+        this.id = seller.getId();
+        this.businessNo = seller.getBusinessNo();
+        this.brandName = seller.getBrandName();
+        this.brandLogo = seller.getBrandLogo();
+        this.status = seller.getStatus();
+    }
+}

--- a/src/main/java/com/example/dropshop/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/dropshop/domain/seller/entity/Seller.java
@@ -1,0 +1,59 @@
+package com.example.dropshop.domain.seller.entity;
+
+import com.example.dropshop.common.entity.BaseEntity;
+import com.example.dropshop.domain.seller.enums.SellerStatus;
+import com.example.dropshop.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seller extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 10, unique = true)
+    private String businessNo; // 사업자 번호 10자리
+
+    @Column(nullable = false)
+    private String brandName;
+
+    private String brandLogo;
+
+    @Column(nullable = false)
+    private String accountInfo; // 정산 계좌 정보
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SellerStatus status;
+
+    @Builder
+    public Seller(User user, String businessNo, String brandName, String brandLogo, String accountInfo) {
+        this.user = user;
+        this.businessNo = businessNo;
+        this.brandName = brandName;
+        this.brandLogo = brandLogo;
+        this.accountInfo = accountInfo;
+        this.status = SellerStatus.PENDING;
+    }
+
+    public void updateInfo(String brandName, String brandLogo, String accountInfo) {
+        this.brandName = brandName;
+        this.brandLogo = brandLogo;
+        this.accountInfo = accountInfo;
+    }
+
+    public void approve() {
+        this.status = SellerStatus.APPROVED;
+    }
+}

--- a/src/main/java/com/example/dropshop/domain/seller/enums/SellerStatus.java
+++ b/src/main/java/com/example/dropshop/domain/seller/enums/SellerStatus.java
@@ -1,0 +1,5 @@
+package com.example.dropshop.domain.seller.enums;
+
+public enum SellerStatus {
+    PENDING, APPROVED, SUSPENDED
+}

--- a/src/main/java/com/example/dropshop/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/com/example/dropshop/domain/seller/repository/SellerRepository.java
@@ -1,0 +1,15 @@
+package com.example.dropshop.domain.seller.repository;
+
+import com.example.dropshop.domain.seller.entity.Seller;
+import com.example.dropshop.domain.seller.enums.SellerStatus;
+import com.example.dropshop.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+    boolean existsByBusinessNo(String businessNo);
+    Optional<Seller> findByUser(User user);
+    List<Seller> findAllByStatus(SellerStatus status);
+}

--- a/src/main/java/com/example/dropshop/domain/seller/service/SellerService.java
+++ b/src/main/java/com/example/dropshop/domain/seller/service/SellerService.java
@@ -1,0 +1,78 @@
+package com.example.dropshop.domain.seller.service;
+
+import com.example.dropshop.domain.seller.dto.request.SellerApplyRequest;
+import com.example.dropshop.domain.seller.dto.request.SellerUpdateRequest;
+import com.example.dropshop.domain.seller.dto.response.SellerResponse;
+import com.example.dropshop.domain.seller.entity.Seller;
+import com.example.dropshop.domain.seller.repository.SellerRepository;
+import com.example.dropshop.domain.user.entity.User;
+import com.example.dropshop.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SellerService {
+
+    private final SellerRepository sellerRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SellerResponse applySeller(String email, SellerApplyRequest request) {
+        // 1. 유저 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 2. 사업자 번호 중복 체크
+        if (sellerRepository.existsByBusinessNo(request.getBusinessNo())) {
+            throw new IllegalArgumentException("이미 등록된 사업자 번호입니다.");
+        }
+
+        // 3. 이미 신청했는지 체크
+        if (sellerRepository.findByUser(user).isPresent()) {
+            throw new IllegalArgumentException("이미 판매자 신청 내역이 존재합니다.");
+        }
+
+        // 4. 저장
+        Seller seller = Seller.builder()
+                .user(user)
+                .businessNo(request.getBusinessNo())
+                .brandName(request.getBrandName())
+                .brandLogo(request.getBrandLogo())
+                .accountInfo(request.getAccountInfo())
+                .build();
+
+        return new SellerResponse(sellerRepository.save(seller));
+    }
+
+    public SellerResponse getMySellerStatus(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Seller seller = sellerRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("판매자 신청 내역이 없습니다."));
+        return new SellerResponse(seller);
+    }
+
+    @Transactional
+    public SellerResponse updateSeller(String email, SellerUpdateRequest request) {
+        // 1. 유저 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 2. 해당 유저의 판매자 정보 조회
+        Seller seller = sellerRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("판매자 정보를 찾을 수 없습니다."));
+
+        // 3. 정보 업데이트 (엔티티 내부에 만든 updateInfo 메서드 활용)
+        seller.updateInfo(
+                request.getBrandName(),
+                request.getBrandLogo(),
+                request.getAccountInfo()
+        );
+
+        return new SellerResponse(seller);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 판매자(Seller) 도메인 구현 및 자동 승인 스케줄러 추가
---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

1. 판매자(Seller) 도메인 구축

Entity: Seller 엔티티 생성 및 User와 1:1 관계 매핑

Enum: 판매자 상태 관리(PENDING, APPROVED, SUSPENDED)

Repository: 사업자 번호 중복 검증 및 유저별 조회 메서드 구현

2. API 및 비즈니스 로직
신청 (POST /apply): 중복 신청/사업자 번호 검증 후 PENDING 상태로 저장

조회 (GET /me/status): 로그인 유저의 판매자 승인 현황 확인

수정 (PATCH /me): 브랜드명, 로고, 계좌 정보 등 판매자 정보 업데이트

3. 자동 승인 스케줄러
@Scheduled 활용: PENDING 상태의 판매자를 주기적으로 자동 승인(APPROVED) 처리하는 가상 프로세스 도입

4. 보안 및 안정성
Security 연동: AuthenticationPrincipal을 통해 유저 정보를 안전하게 조회 및 활용

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.