### PR TITLE
feat : 판매자 드롭 목록 조회 API 및 상품별 드롭 이력 조회 API 구현

### DIFF
--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
@@ -7,11 +7,18 @@ import com.example.dropshop.domain.drops.dto.request.DropUpdateRequest;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.exception.DropsException;
 import com.example.dropshop.domain.drops.service.DropsFacadeService;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DropsController {
 
   private final DropsFacadeService dropsFacadeService;
+  private final DropsQueryService dropsQueryService;
 
   /**
    * 판매자가 새로운 드랍을 생성한다.
@@ -115,6 +123,24 @@ public class DropsController {
     if (role != null && !"SELLER".equalsIgnoreCase(role)) {
       throw new DropsException(ErrorCode.SELLER_ROLE_REQUIRED);
     }
+  }
+
+  /**
+   * 판매자 본인 드롭 목록 조회.
+   */
+  @GetMapping("/mine")
+  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getMyDrops(
+      @RequestHeader("X-SELLER-ID") Long sellerId,
+      @RequestHeader(value = "X-ROLE", required = false) String role,
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable
+  ) {
+    validateSellerRole(role);
+    Page<DropListItemResponse> response = dropsQueryService.findSellerDrops(
+        sellerId,
+        pageable
+    );
+    return ResponseEntity.ok(ApiResponse.ok(response));
   }
 }
 

--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
@@ -1,0 +1,68 @@
+package com.example.dropshop.domain.drops.controller;
+
+import com.example.dropshop.common.dto.ApiResponse;
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 공개 드롭 조회 API 컨트롤러.
+ * 기술:
+ * - CQRS 패턴: Command(생성/수정/삭제)와 Query(조회) 분리
+ * - 읽기 전용 트랜잭션으로 성능 최적화
+ * - @PageableDefault: 기본 페이징 설정
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/drops")
+public class DropsQueryController {
+
+  private final DropsQueryService dropsQueryService;
+
+  /**
+   * 공개 드롭 목록 조회.
+   * - SCHEDULED(예정), ACTIVE(진행), FINISHED(종료) 상태 드롭 조회
+   * - 페이징 지원
+   * - 기본 정렬: 생성일시 역순
+   */
+  @GetMapping
+  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getPublicDrops(
+      @RequestParam(required = false) DropsStatus status,
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable
+  ) {
+    Page<DropListItemResponse> response = dropsQueryService.findPublicDrops(status, pageable);
+    return ResponseEntity.ok(ApiResponse.ok(response));
+  }
+
+  /**
+   * 드롭 상세 조회.
+   * - 공개 상태 드롭만 조회 가능
+   * - 선착순 여부(useQueue) 포함
+   * - 현재 잔여 재고 표시
+   */
+  @GetMapping("/{dropId}")
+  public ResponseEntity<ApiResponse<DropResponse>> getDropDetail(
+      @PathVariable Long dropId
+  ) {
+    DropResponse response = dropsQueryService.findPublicDropDetail(dropId);
+    return ResponseEntity.ok(ApiResponse.ok(response));
+  }
+
+}
+
+
+
+

--- a/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
@@ -1,0 +1,43 @@
+package com.example.dropshop.domain.drops.controller;
+
+import com.example.dropshop.common.dto.ApiResponse;
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 상품별 드롭 이력 조회 API 컨트롤러.
+ * 기술 설명.
+ * - 드롭 조회 책임을 공개 조회 컨트롤러와 분리해 명확한 라우팅 유지
+ * - Page 응답을 공통 ApiResponse.PageResponse 형식으로 래핑
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductDropsQueryController {
+
+  private final DropsQueryService dropsQueryService;
+
+  /**
+   * 특정 상품의 드롭 이력을 조회한다.
+   */
+  @GetMapping("/{productId}/drops")
+  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getDropsByProduct(
+      @PathVariable Long productId,
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable
+  ) {
+    Page<DropListItemResponse> response = dropsQueryService.findDropsByProduct(productId, pageable);
+    return ResponseEntity.ok(ApiResponse.ok(response));
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
@@ -1,0 +1,47 @@
+package com.example.dropshop.domain.drops.dto.response;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 드랍 목록 조회 응답 DTO.
+ */
+@Getter
+@Builder
+public class DropListItemResponse {
+
+  private Long dropId;
+  private Long productId;
+  private String productName;
+  private String thumbnailUrl;
+  private String status;
+  private LocalDateTime startAt;
+  private LocalDateTime endAt;
+  private Long soldCount;
+  private Long remainStock;
+  private Long purchaseLimit;
+  private boolean useQueue;
+
+  /**
+   * 드랍 엔티티를 목록 응답 DTO로 변환한다.
+   */
+  public static DropListItemResponse from(Drops drops) {
+    return DropListItemResponse.builder()
+        .dropId(drops.getId())
+        .productId(drops.getProduct().getId())
+        .productName(drops.getProduct().getName())
+        .thumbnailUrl(drops.getProduct().getThumbnailUrl())
+        .status(drops.getStatus().name())
+        .startAt(drops.getStartAt())
+        .endAt(drops.getEndAt())
+        .soldCount(drops.getTotalStock() - drops.getRemainStock())
+        .remainStock(drops.getRemainStock())
+        .purchaseLimit(drops.getPurchaseLimit())
+        .useQueue(drops.isUseQueue())
+        .build();
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
+++ b/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
@@ -1,11 +1,12 @@
 package com.example.dropshop.domain.drops.repository;
 
-import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.entity.Drops;
-import java.time.LocalDateTime;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -14,31 +15,35 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface DropsRepository extends JpaRepository<Drops, Long> {
 
   /**
-   * 특정 상품의 드랍 목록을 시작 시간 역순으로 조회한다.
+   * 공개 드롭 목록을 페이징으로 조회한다 (Product 함께 로드).
    */
-  List<Drops> findAllByProductIdOrderByStartAtDesc(Long productId);
+  @EntityGraph(attributePaths = "product")
+  Page<Drops> findAllByStatusIn(Collection<DropsStatus> statuses, Pageable pageable);
 
   /**
-   * 상태 기준으로 드랍 목록을 시작 시간 오름차순 조회한다.
+   * 공개 가능한 상태의 특정 드롭을 조회한다 (Product 함께 로드).
    */
-  List<Drops> findAllByStatusOrderByStartAtAsc(DropsStatus status);
+  @EntityGraph(attributePaths = "product")
+  Optional<Drops> findOneByIdAndStatusIn(Long id, Collection<DropsStatus> statuses);
 
   /**
-   * 특정 상품의 특정 상태 드랍을 조회한다.
+   * 특정 상품의 공개 상태 드롭 이력을 페이징으로 조회한다 (Product 함께 로드).
    */
-  Optional<Drops> findByProductIdAndStatus(Long productId, DropsStatus status);
+  @EntityGraph(attributePaths = "product")
+  Page<Drops> findAllByProductIdAndStatusIn(
+      Long productId,
+      Collection<DropsStatus> statuses,
+      Pageable pageable
+  );
+
+  /**
+   * 판매자 본인 상품의 드롭을 페이징으로 조회한다 (Product 함께 로드).
+   */
+  @EntityGraph(attributePaths = "product")
+  Page<Drops> findAllByProduct_SellerIdOrderByCreatedAtDesc(Long sellerId, Pageable pageable);
 
   /**
    * 특정 상품에 지정 상태의 드랍이 존재하는지 확인한다.
    */
   boolean existsByProductIdAndStatusIn(Long productId, Collection<DropsStatus> statuses);
-
-  /**
-   * 지정된 시간 구간에 포함되는 드랍을 상태 기준으로 조회한다.
-   */
-  List<Drops> findAllByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
-      DropsStatus status,
-      LocalDateTime startAt,
-      LocalDateTime endAt
-  );
 }

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
@@ -1,0 +1,109 @@
+package com.example.dropshop.domain.drops.service;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.exception.DropsException;
+import com.example.dropshop.domain.drops.repository.DropsRepository;
+import java.util.EnumSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 드랍 조회 서비스 (읽기 최적화).
+ * 기술 설명.
+ * - @Transactional(readOnly = true): 읽기 전용으로 플러시 모드 NEVER, 스냅샷 비활성화 최적화
+ * - @EntityGraph: N+1 쿼리 방지, Product를 함께 로드
+ * - Page<T>: 페이징, 정렬, 총 개수 자동 계산
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DropsQueryService {
+
+  private static final Set<DropsStatus> PUBLIC_VISIBLE_STATUSES = EnumSet.of(
+      DropsStatus.SCHEDULED,
+      DropsStatus.ACTIVE,
+      DropsStatus.FINISHED
+  );
+
+  private final DropsRepository dropsRepository;
+
+  /**
+   * 공개 드롭 목록을 조회한다.
+   * 도메인 규칙.
+   * - SCHEDULED: 예정 드롭 (진행 전)
+   * - ACTIVE: 진행 중 드롭
+   * - FINISHED: 종료된 드롭
+   * 기술.
+   * - @EntityGraph로 Product 즉시 로드 (N+1 방지)
+   * - Page 객체로 페이징/정렬/총 개수 자동 처리
+   */
+  public Page<DropListItemResponse> findPublicDrops(DropsStatus status, Pageable pageable) {
+    Set<DropsStatus> filterStatuses = status == null
+        ? PUBLIC_VISIBLE_STATUSES
+        : EnumSet.of(status);
+
+    Page<Drops> drops = dropsRepository.findAllByStatusIn(filterStatuses, pageable);
+    return drops.map(DropListItemResponse::from);
+  }
+
+  /**
+   * 드롭 상세 조회.
+   * 도메인 규칙.
+   * - SCHEDULED, ACTIVE, FINISHED만 공개 조회 가능
+   * - useQueue 여부 표시 (규칙 4번: 선착순 드롭 구분)
+   */
+  public DropResponse findPublicDropDetail(Long dropId) {
+    Drops drops = dropsRepository.findOneByIdAndStatusIn(dropId, PUBLIC_VISIBLE_STATUSES)
+        .orElseThrow(() -> new DropsException(ErrorCode.DROP_NOT_FOUND));
+
+    return DropResponse.from(drops);
+  }
+
+  /**
+   * 판매자 본인 드롭 목록 조회.
+   * 도메인 규칙.
+   * - 판매자는 본인이 등록한 상품의 드롭만 조회 가능
+   * - 모든 상태(SCHEDULED, ACTIVE, FINISHED)의 드롭 조회 가능
+   */
+  public Page<DropListItemResponse> findSellerDrops(
+      Long sellerId,
+      Pageable pageable
+  ) {
+    Page<Drops> drops = dropsRepository.findAllByProduct_SellerIdOrderByCreatedAtDesc(
+        sellerId,
+        pageable
+    );
+    return drops.map(DropListItemResponse::from);
+  }
+
+  /**
+   * 특정 상품의 드롭 이력 조회.
+   * 도메인 규칙.
+   * - 공개 상태 드롭만 조회 가능
+   * - 판매된 수량(totalStock - remainStock) 포함
+   */
+  public Page<DropListItemResponse> findDropsByProduct(
+      Long productId,
+      Pageable pageable
+  ) {
+    Page<Drops> drops = dropsRepository.findAllByProductIdAndStatusIn(
+        productId,
+        PUBLIC_VISIBLE_STATUSES,
+        pageable
+    );
+
+    return drops.map(DropListItemResponse::from);
+  }
+}
+
+
+
+


### PR DESCRIPTION
## 📌 PR 제목
feat: 판매자 드롭 목록 조회 API 및 상품별 드롭 이력 조회 API 구현

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- **공개 드롭 목록 조회 API 구현** (`GET /api/v1/drops`)
  - 상태(status) 필터링 지원 (미입력 시 공개 가능한 전체 상태 조회)
  - 기본 정렬: 생성일시 역순, 기본 페이지 크기 20
- **드롭 상세 조회 API 구현** (`GET /api/v1/drops/{dropId}`)
  - 공개 상태(SCHEDULED / ACTIVE / FINISHED)의 드롭만 조회 가능
- **상품별 드롭 이력 조회 API 구현** (`GET /api/v1/products/{productId}/drops`)
  - 특정 상품에 등록된 공개 상태 드롭 이력을 페이징으로 조회
- **`DropsQueryService` 신규 생성** (CQRS 패턴 적용)
  - 읽기 전용 트랜잭션(`@Transactional(readOnly = true)`)으로 성능 최적화
  - Command(생성/수정/삭제)와 Query(조회) 서비스 분리
- **`DropListItemResponse` DTO 신규 생성**
  - 드롭 목록 응답용 DTO (판매 수량, 잔여 재고, 선착순 여부 포함)
- **`DropsRepository` 리팩토링**
  - `@EntityGraph`를 활용해 Product 즉시 로드 (N+1 쿼리 방지)
  - 기존 단순 조회 메서드를 페이징 지원 메서드로 교체
---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [x] 예외 처리 확인

---

## 💡 참고 사항
- **CQRS 패턴 적용**: 기존 `DropsFacadeService`(Command)와 신규 `DropsQueryService`(Query)를 분리하여 역할을 명확히 구분했습니다.
- **N+1 방지**: `DropsRepository`의 조회 메서드에 `@EntityGraph(attributePaths = "product")`를 적용하여 드롭 목록 조회 시 Product를 한 번의 쿼리로 함께 로드합니다.
- **컨트롤러 분리**: 공개 드롭 조회(`DropsQueryController`)와 상품별 드롭 이력 조회(`ProductDropsQueryController`)를 별도 컨트롤러로 분리하여 라우팅 책임을 명확히 했습니다.
- **판매자 드롭 조회**는 기존 `DropsController`의 `GET /api/v1/drops/mine`으로 제공되며, 역할 검증 로직(`validateSellerRole`)을 재사용합니다.
