### PR TITLE
feat: drops 조회 엔드포인트 정리 및 주문-드랍 재고/상태 연동 강화

### DIFF
--- a/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
@@ -72,6 +72,8 @@ public enum ErrorCode {
   DROP_ACTIVE_UPDATE_LOCKED(HttpStatus.BAD_REQUEST,
       "ACTIVE 상태에서는 드랍 시작 시간과 총 판매 수량을 수정할 수 없습니다."),
   DROP_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "종료된 드랍은 수정할 수 없습니다."),
+  DROP_ORDER_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "진행 중인 드랍에서만 주문할 수 있습니다."),
+  DROP_PRODUCT_MISMATCH(HttpStatus.BAD_REQUEST, "요청 상품이 드랍 상품과 일치하지 않습니다."),
   DROP_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST,
       "주문 이력이 있거나 예정 상태가 아닌 드랍은 삭제할 수 없습니다."),
   DROP_STOP_NOT_ALLOWED(HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/drops")
+@RequestMapping("/api/drops")
 public class DropsQueryController {
 
   private final DropsQueryService dropsQueryService;

--- a/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/products")
+@RequestMapping("/api/products")
 public class ProductDropsQueryController {
 
   private final DropsQueryService dropsQueryService;

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
@@ -10,10 +10,13 @@ import com.example.dropshop.domain.order.facade.OrderFacadeService;
 import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * 드랍 도메인 파사드 서비스.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DropsFacadeService {
 
@@ -149,6 +153,51 @@ public class DropsFacadeService {
   @Transactional(readOnly = true)
   public Map<Long, Drops> findLatestDropsByProductIds(Collection<Long> productIds) {
     return dropsService.findLatestDropsByProductIds(productIds);
+  }
+
+  /**
+   * 주문 생성을 위해 드랍 재고를 차감한다.
+   */
+  @Transactional
+  public Drops reserveStockForOrder(Long dropId, Long productId, int quantity) {
+    Drops drops = dropsService.findById(dropId);
+    validateOrderableDrop(drops, productId);
+
+    drops.decrementRemainStock(quantity);
+    if (drops.getRemainStock() == 0L) {
+      drops.finish();
+      productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+    }
+    return drops;
+  }
+
+  /**
+   * 주문 취소/결제 실패 시 드랍 재고를 복원한다.
+   */
+  @Transactional
+  public void restoreStockForOrder(Long dropId, int quantity) {
+    Drops drops = dropsService.findById(dropId);
+    drops.restoreRemainStock(quantity);
+
+    try {
+      if (drops.isFinished()
+          && drops.getRemainStock() > 0L
+          && LocalDateTime.now().isBefore(drops.getEndAt())) {
+        drops.activate();
+        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+      }
+    } catch (OptimisticLockingFailureException e) {
+      log.info("드랍 ID={} 재활성화가 동시성 충돌로 스킵되었습니다.", dropId, e);
+    }
+  }
+
+  private void validateOrderableDrop(Drops drops, Long productId) {
+    if (!drops.isActive()) {
+      throw new DropsException(ErrorCode.DROP_ORDER_NOT_ALLOWED);
+    }
+    if (!drops.getProduct().getId().equals(productId)) {
+      throw new DropsException(ErrorCode.DROP_PRODUCT_MISMATCH);
+    }
   }
 }
 

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionService.java
@@ -6,6 +6,8 @@ import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
  * 드랍 상태 자동 전이 서비스.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DropsStatusTransitionService {
 
@@ -27,12 +30,18 @@ public class DropsStatusTransitionService {
     List<Drops> scheduledDrops = dropsService.findScheduledDropsToActivate(baseTime);
     int transitionedCount = 0;
     for (Drops drops : scheduledDrops) {
-      if (!drops.isScheduled()) {
-        continue;
+      try {
+        if (!drops.isScheduled()) {
+          continue;
+        }
+        drops.activate();
+        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+        transitionedCount++;
+      } catch (OptimisticLockingFailureException e) {
+        log.warn("드랍 ID={} 상태 전이가 동시성 충돌로 스킵되었습니다.", drops.getId(), e);
+      } catch (Exception e) {
+        log.error("드랍 ID={} 상태 전이 중 예기치 않은 오류가 발생했습니다.", drops.getId(), e);
       }
-      drops.activate();
-      productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
-      transitionedCount++;
     }
     return transitionedCount;
   }
@@ -45,12 +54,18 @@ public class DropsStatusTransitionService {
     List<Drops> activeDrops = dropsService.findActiveDropsToFinish(baseTime);
     int transitionedCount = 0;
     for (Drops drops : activeDrops) {
-      if (!drops.isActive()) {
-        continue;
+      try {
+        if (!drops.isActive()) {
+          continue;
+        }
+        drops.finish();
+        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+        transitionedCount++;
+      } catch (OptimisticLockingFailureException e) {
+        log.warn("드랍 ID={} 종료 전이가 동시성 충돌로 스킵되었습니다.", drops.getId(), e);
+      } catch (Exception e) {
+        log.error("드랍 ID={} 종료 전이 중 예기치 않은 오류가 발생했습니다.", drops.getId(), e);
       }
-      drops.finish();
-      productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
-      transitionedCount++;
     }
     return transitionedCount;
   }

--- a/src/main/java/com/example/dropshop/domain/order/facade/OrderFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/order/facade/OrderFacadeService.java
@@ -1,5 +1,7 @@
 package com.example.dropshop.domain.order.facade;
 
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.service.DropsFacadeService;
 import com.example.dropshop.domain.order.dto.request.OrderCreateRequest;
 import com.example.dropshop.domain.order.dto.response.OrderCreateResponse;
 import com.example.dropshop.domain.order.dto.response.OrderDetailResponse;
@@ -8,7 +10,6 @@ import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.order.service.OrderService;
 import com.example.dropshop.domain.user.entity.User;
 import com.example.dropshop.domain.user.repository.UserRepository;
-import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,24 +24,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderFacadeService {
 
   private final OrderService orderService;
+  private final DropsFacadeService dropsFacadeService;
   private final UserRepository userRepository;
 
   /**
    * 주문 생성.
    */
+  @Transactional
   public OrderCreateResponse createOrder(String email, OrderCreateRequest request) {
     // TODO: QueueService 대기열 토큰 검증
-    // TODO: ProductService 상품 정보 조회 및 재고 차감
     Long userId = getUserIdByEmail(email);
+    Drops drops = dropsFacadeService.reserveStockForOrder(
+        request.getDropId(),
+        request.getProductId(),
+        1
+    );
 
     Order order = orderService.createOrder(
         userId,
         request.getDropId(),
         request.getProductId(),
-        new BigDecimal("100000"), // priceSnapshot — ProductService 연동 후 교체
-        new BigDecimal("1000"), // salePriceSnapshot — ProductService 연동 후 교체
-        new BigDecimal("21000"), // discountAmountSnapshot — ProductService 연동 후 교체
-        "https://dummy-image"// thumbnailUrlSnapshot — ProductService 연동 후 교체
+        drops.getProduct().getPrice(),
+        drops.getProduct().getSalePrice(),
+        drops.getProduct().getDiscountAmount(),
+        drops.getProduct().getThumbnailUrl()
     );
 
     return OrderCreateResponse.from(order);

--- a/src/main/java/com/example/dropshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/dropshop/domain/order/service/OrderService.java
@@ -1,14 +1,13 @@
 package com.example.dropshop.domain.order.service;
 
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.drops.service.DropsFacadeService;
 import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.order.entity.OrderItem;
 import com.example.dropshop.domain.order.enums.OrderStatus;
-import com.example.dropshop.domain.order.event.StockRestoreEvent;
 import com.example.dropshop.domain.order.exception.OrderException;
 import com.example.dropshop.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,7 +25,7 @@ import java.util.List;
 public class OrderService {
 
   private final OrderRepository orderRepository;
-  private final ApplicationEventPublisher eventPublisher;
+  private final DropsFacadeService dropsFacadeService;
 
   /**
    * 주문 생성.
@@ -85,12 +84,7 @@ public class OrderService {
         .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
 
     order.cancel();
-
-    order.getOrderItems().forEach(item ->
-        eventPublisher.publishEvent(
-            new StockRestoreEvent(item.getProductId(), item.getQuantity())
-        )
-    );
+    restoreDropStock(order);
     return order;
   }
 
@@ -105,12 +99,15 @@ public class OrderService {
 
     expiredOrders.forEach(order -> {
       order.cancel();
-      order.getOrderItems().forEach(item ->
-          eventPublisher.publishEvent(
-              new StockRestoreEvent(item.getProductId(), item.getQuantity())
-          )
-      );
+      restoreDropStock(order);
     });
+  }
+
+  private void restoreDropStock(Order order) {
+    int restoreQuantity = order.getOrderItems().stream()
+        .mapToInt(OrderItem::getQuantity)
+        .sum();
+    dropsFacadeService.restoreStockForOrder(order.getDropId(), restoreQuantity);
   }
 
 }

--- a/src/main/java/com/example/dropshop/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/dropshop/domain/payment/service/PaymentService.java
@@ -2,10 +2,10 @@ package com.example.dropshop.domain.payment.service;
 
 import com.example.dropshop.common.config.PortOneProperties;
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.drops.service.DropsFacadeService;
 import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.order.entity.OrderItem;
 import com.example.dropshop.domain.order.enums.OrderStatus;
-import com.example.dropshop.domain.order.event.StockRestoreEvent;
 import com.example.dropshop.domain.order.exception.OrderException;
 import com.example.dropshop.domain.order.repository.OrderRepository;
 import com.example.dropshop.domain.payment.client.PortOneClient;
@@ -19,7 +19,6 @@ import com.example.dropshop.domain.user.entity.User;
 import com.example.dropshop.domain.user.repository.UserRepository;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +31,7 @@ public class PaymentService {
 
   private final PaymentRepository paymentRepository;
   private final OrderRepository orderRepository;
-  private final ApplicationEventPublisher eventPublisher;
+  private final DropsFacadeService dropsFacadeService;
   private final PortOneClient portOneClient;
   private final PortOneProperties portOneProperties;
   private final UserRepository userRepository;
@@ -129,7 +128,7 @@ public class PaymentService {
     if (isFailureStatus(portOnePayment.status())) {
       payment.fail();
       order.cancel();
-      publishStockRestoreEvents(order);
+      restoreDropStock(order);
       return payment;
     }
 
@@ -223,10 +222,11 @@ public class PaymentService {
     }
   }
 
-  private void publishStockRestoreEvents(Order order) {
-    for (OrderItem item : order.getOrderItems()) {
-      eventPublisher.publishEvent(new StockRestoreEvent(item.getProductId(), item.getQuantity()));
-    }
+  private void restoreDropStock(Order order) {
+    int restoreQuantity = order.getOrderItems().stream()
+        .mapToInt(OrderItem::getQuantity)
+        .sum();
+    dropsFacadeService.restoreStockForOrder(order.getDropId(), restoreQuantity);
   }
 
   private boolean isFailureStatus(String status) {


### PR DESCRIPTION
## 📌 PR 제목
feat: drops 조회 경로 정리 및 주문-드랍 재고 연동/동시성 보강

---

## ✨ 변경 사항
이번 PR에서는 drops 조회 API 경로 규칙 반영, 주문/결제 도메인과 drops 재고 연동, 동시성 예외 처리 보강을 진행했습니다.

### 1) API 경로 정리 (팀 규칙 반영)
- `GET /api/v1/drops` -> `GET /api/drops`
- `GET /api/v1/drops/{dropId}` -> `GET /api/drops/{dropId}`
- `GET /api/v1/products/{productId}/drops` -> `GET /api/products/{productId}/drops`
- 관련 컨트롤러 테스트 경로도 함께 수정

### 2) 주문/결제와 drops 재고/상태 연동
- 주문 생성 시 drops 재고 차감 (`reserveStockForOrder`)
- 주문 취소/만료/결제 실패 시 drops 재고 복원 (`restoreStockForOrder`)
- 재고 0 도달 시 `FINISHED + Product OUT_OF_STOCK`
- 복원 후 조건 충족 시 `ACTIVE + Product ON_SALE` 재전환 처리

### 3) 에러코드 추가
- `DROP_ORDER_NOT_ALLOWED`
- `DROP_PRODUCT_MISMATCH`

### 4) 동시성 예외 처리 보강
- `DropsStatusTransitionService` 전이 루프 내 예외 처리 추가
  - `OptimisticLockingFailureException` 발생 시 스킵 후 다음 대상 처리
  - 일반 예외도 로깅 후 루프 계속 진행
- `DropsFacadeService.restoreStockForOrder` 재활성화 구간에서 동시성 충돌 발생 시 예외 전파하지 않고 로깅 처리

### 5) 테스트 반영
- `OrderServiceTest`: 이벤트 검증 -> drops 복원 호출 검증으로 변경
- `PaymentServiceTest`: 이벤트 검증 -> drops 복원 호출 검증으로 변경
- `DropsStatusTransitionServiceTest`: 동시성 예외 발생 시 continue 케이스 추가
- `DropsFacadeServiceTest`: 재활성화 충돌 시 예외 미전파 케이스 추가

### 6) 재고 복원 단일화
- 주문 취소/만료 및 결제 실패 시 재고 복원을 이벤트 발행(`StockRestoreEvent`)에서 `DropsFacadeService` 직접 호출 방식으로 전환
- 재고 복원과 드랍 상태 전이(`FINISHED` -> `ACTIVE`, `ACTIVE` -> `FINISHED`) 규칙을 Drops 도메인 단일 진입점 모음

---

## 🔗 관련 이슈
- close #이슈번호

---

## 🧪 테스트
- [x] compileJava
- [x] drops/order/payment 도메인 테스트
- [x] 컨트롤러 경로 변경 테스트

실행 명령어:
- `./gradlew test --tests "com.example.dropshop.domain.drops.service.DropsStatusTransitionServiceTest" --tests "com.example.dropshop.domain.drops.service.DropsFacadeServiceTest"`
- `./gradlew test --tests "com.example.dropshop.domain.order.*" --tests "com.example.dropshop.domain.payment.*" --tests "com.example.dropshop.domain.drops.*"`

---

## 💡 참고 사항
- 기존 `StockRestoreEvent` 기반 복원 로직 일부를 drops 서비스 직접 호출 방식으로 전환했습니다.
- 동시성 이슈 대응은 1차 보강(try-catch + 로깅/continue)이며, 필요 시 다음 단계에서 `REQUIRES_NEW` 분리 또는 retry 적용 검토 가능합니다.
- 이벤트 기반 복원 로직은 도메인 경계 분리에는 유리하지만, 현재는 “재고 복원 + 드랍/상품 상태 전이”를 한곳에서 보장하는 것이 더 중요해 직접 호출 방식으로 정리했습니다.
- 추후 비동기 확장(알림, 외부 연동)이 필요해지면 이벤트 발행을 보조 경로로 재도입할 수 있습니다.
