### PR TITLE
refactor: 판매자 인증 방식을 커스텀 헤더에서 JWT 기반 Spring Security로 전환

### DIFF
--- a/src/main/java/com/example/dropshop/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/SecurityConfig.java
@@ -32,9 +32,11 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능한 경로
                         .requestMatchers("/api/auth/login", "/api/auth/refresh").permitAll()
                         .requestMatchers("/api/users/signup").permitAll()
+                        .requestMatchers("/api/sellers/drops/**").hasRole("SELLER")
+                        .requestMatchers("/api/sellers/products/**").hasRole("SELLER")
+                        .requestMatchers("/api/sellers/images/**").hasRole("SELLER")
                         .requestMatchers("/api/sellers/**").permitAll() // TODO: JWT 구현 후 제거
                         .requestMatchers("/api/products/**").permitAll() // TODO: JWT 구현 후 제거
-                        .requestMatchers("/api/sellers/**").permitAll()
                         .requestMatchers("/payments/**").permitAll()
                         .requestMatchers("/api/payments/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/dropshop/common/security/SellerAuthContext.java
+++ b/src/main/java/com/example/dropshop/common/security/SellerAuthContext.java
@@ -1,0 +1,8 @@
+package com.example.dropshop.common.security;
+
+/**
+ * 판매자 인증 컨텍스트.
+ */
+public record SellerAuthContext(Long sellerId, boolean sellerApproved, boolean sellerVerified) {
+}
+

--- a/src/main/java/com/example/dropshop/common/security/SellerAuthResolver.java
+++ b/src/main/java/com/example/dropshop/common/security/SellerAuthResolver.java
@@ -1,0 +1,57 @@
+package com.example.dropshop.common.security;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.exception.ServiceException;
+import com.example.dropshop.domain.seller.entity.Seller;
+import com.example.dropshop.domain.seller.enums.SellerStatus;
+import com.example.dropshop.domain.seller.service.SellerFacadeService;
+import com.example.dropshop.domain.user.entity.User;
+import com.example.dropshop.domain.user.enums.UserRole;
+import com.example.dropshop.domain.user.service.UserFacadeService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * 판매자 인증 컨텍스트를 해석한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SellerAuthResolver {
+
+  private static final String ANONYMOUS_USER = "anonymousUser";
+
+  private final UserFacadeService userFacadeService;
+  private final SellerFacadeService sellerFacadeService;
+
+  /**
+   * JWT 인증 정보를 기반으로 판매자 인증 컨텍스트를 해석한다.
+   */
+  public SellerAuthContext resolve(Authentication authentication) {
+    String email = authentication == null ? null : authentication.getName();
+    if (email == null || email.isBlank() || ANONYMOUS_USER.equals(email)) {
+      throw new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED);
+    }
+    return resolveFromJwt(email);
+  }
+
+  private SellerAuthContext resolveFromJwt(String email) {
+    User user = userFacadeService.findByEmail(email)
+        .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+    if (user.getRole() != UserRole.SELLER) {
+      throw new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED);
+    }
+
+    Seller seller = sellerFacadeService.findByUser(user)
+        .orElseThrow(() -> new ServiceException(ErrorCode.SELLER_NOT_FOUND));
+    boolean sellerApproved = seller.getStatus() == SellerStatus.APPROVED;
+    boolean sellerVerified = seller.getAccountInfo() != null
+        && !seller.getAccountInfo().isBlank();
+
+    // Product/Drops 도메인의 sellerId는 Seller PK가 아니라 User PK 기준이다.
+    return new SellerAuthContext(user.getId(), sellerApproved, sellerVerified);
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
@@ -1,14 +1,14 @@
 package com.example.dropshop.domain.drops.controller;
 
 import com.example.dropshop.common.dto.ApiResponse;
-import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
 import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
 import com.example.dropshop.domain.drops.dto.request.DropUpdateRequest;
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
-import com.example.dropshop.domain.drops.exception.DropsException;
 import com.example.dropshop.domain.drops.service.DropsFacadeService;
 import com.example.dropshop.domain.drops.service.DropsQueryService;
-import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,13 +17,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,23 +37,21 @@ public class DropsController {
 
   private final DropsFacadeService dropsFacadeService;
   private final DropsQueryService dropsQueryService;
+  private final SellerAuthResolver sellerAuthResolver;
 
   /**
    * 판매자가 새로운 드랍을 생성한다.
    */
   @PostMapping
   public ResponseEntity<ApiResponse<DropResponse>> createDrop(
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody DropCreateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     DropResponse response = dropsFacadeService.createSellerDrop(
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
@@ -65,18 +63,15 @@ public class DropsController {
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<DropResponse>> updateDrop(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody DropUpdateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     DropResponse response = dropsFacadeService.updateSellerDrop(
         id,
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
@@ -88,13 +83,15 @@ public class DropsController {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteDrop(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified
+      Authentication authentication
   ) {
-    validateSellerRole(role);
-    dropsFacadeService.deleteSellerDrop(id, sellerId, sellerApproved, sellerVerified);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    dropsFacadeService.deleteSellerDrop(
+        id,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified()
+    );
     return ResponseEntity.ok(ApiResponse.ok());
   }
 
@@ -104,43 +101,33 @@ public class DropsController {
   @PatchMapping("/{id}/stop")
   public ResponseEntity<ApiResponse<DropResponse>> stopDrop(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified
+      Authentication authentication
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     DropResponse response = dropsFacadeService.stopSellerDrop(
         id,
-        sellerId,
-        sellerApproved,
-        sellerVerified
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified()
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
-  }
-
-  private void validateSellerRole(String role) {
-    if (role != null && !"SELLER".equalsIgnoreCase(role)) {
-      throw new DropsException(ErrorCode.SELLER_ROLE_REQUIRED);
-    }
   }
 
   /**
    * 판매자 본인 드롭 목록 조회.
    */
   @GetMapping("/mine")
-  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getMyDrops(
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
+  public ResponseEntity<
+      ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getMyDrops(
+      Authentication authentication,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
       Pageable pageable
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     Page<DropListItemResponse> response = dropsQueryService.findSellerDrops(
-        sellerId,
+        sellerAuth.sellerId(),
         pageable
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
   }
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/dropshop/domain/product/controller/ProductController.java
@@ -1,7 +1,8 @@
 package com.example.dropshop.domain.product.controller;
 
 import com.example.dropshop.common.dto.ApiResponse;
-import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
 import com.example.dropshop.domain.product.dto.request.ProductCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageUpdateRequest;
@@ -10,7 +11,6 @@ import com.example.dropshop.domain.product.dto.request.ProductUpdateRequest;
 import com.example.dropshop.domain.product.dto.response.ProductCreateResponse;
 import com.example.dropshop.domain.product.dto.response.ProductImageResponse;
 import com.example.dropshop.domain.product.dto.response.SellerProductListItemResponse;
-import com.example.dropshop.domain.product.exception.ProductException;
 import com.example.dropshop.domain.product.service.ProductFacadeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +19,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,24 +39,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
   private final ProductFacadeService productFacadeService;
+  private final SellerAuthResolver sellerAuthResolver;
 
   /**
    * 판매자가 새로운 상품을 등록한다.
    */
   @PostMapping
   public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody ProductCreateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
 
     ProductCreateResponse response = productFacadeService.createSellerProduct(
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
 
@@ -69,18 +67,15 @@ public class ProductController {
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<ProductCreateResponse>> updateProduct(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody ProductUpdateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     ProductCreateResponse response = productFacadeService.updateSellerProduct(
         id,
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
@@ -92,18 +87,15 @@ public class ProductController {
   @PatchMapping("/{id}/status")
   public ResponseEntity<ApiResponse<ProductCreateResponse>> updateProductStatus(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody ProductStatusUpdateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     ProductCreateResponse response = productFacadeService.changeSellerProductStatus(
         id,
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
@@ -115,13 +107,15 @@ public class ProductController {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteProduct(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified
+      Authentication authentication
   ) {
-    validateSellerRole(role);
-    productFacadeService.deleteSellerProduct(id, sellerId, sellerApproved, sellerVerified);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    productFacadeService.deleteSellerProduct(
+        id,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified()
+    );
     return ResponseEntity.ok(ApiResponse.ok());
   }
 
@@ -131,18 +125,15 @@ public class ProductController {
   @PostMapping("/{id}/images")
   public ResponseEntity<ApiResponse<ProductImageResponse>> createProductImage(
       @PathVariable Long id,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody ProductImageCreateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     ProductImageResponse response = productFacadeService.createSellerProductImage(
         id,
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
@@ -155,19 +146,16 @@ public class ProductController {
   public ResponseEntity<ApiResponse<ProductImageResponse>> updateProductImage(
       @PathVariable Long id,
       @PathVariable Long imageId,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified,
+      Authentication authentication,
       @Valid @RequestBody ProductImageUpdateRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     ProductImageResponse response = productFacadeService.updateSellerProductImage(
         id,
         imageId,
-        sellerId,
-        sellerApproved,
-        sellerVerified,
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified(),
         request
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
@@ -180,18 +168,15 @@ public class ProductController {
   public ResponseEntity<ApiResponse<Void>> deleteProductImage(
       @PathVariable Long id,
       @PathVariable Long imageId,
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
-      @RequestHeader(value = "X-SELLER-APPROVED", defaultValue = "false") boolean sellerApproved,
-      @RequestHeader(value = "X-SELLER-VERIFIED", defaultValue = "false") boolean sellerVerified
+      Authentication authentication
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     productFacadeService.deleteSellerProductImage(
         id,
         imageId,
-        sellerId,
-        sellerApproved,
-        sellerVerified
+        sellerAuth.sellerId(),
+        sellerAuth.sellerApproved(),
+        sellerAuth.sellerVerified()
     );
     return ResponseEntity.ok(ApiResponse.ok());
   }
@@ -200,24 +185,18 @@ public class ProductController {
    * 판매자 본인 상품 목록을 조회한다.
    */
   @GetMapping("/mine")
-  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<SellerProductListItemResponse>>> findMineProducts(
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
+  public ResponseEntity<
+      ApiResponse<ApiResponse.PageResponse<SellerProductListItemResponse>>> findMineProducts(
+      Authentication authentication,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
     Pageable pageable = PageRequest.of(page, size);
     Page<SellerProductListItemResponse> response = productFacadeService.findSellerProducts(
-        sellerId,
+        sellerAuth.sellerId(),
         pageable
     );
     return ResponseEntity.ok(ApiResponse.ok(response));
-  }
-
-  private void validateSellerRole(String role) {
-    if (role != null && !"SELLER".equalsIgnoreCase(role)) {
-      throw new ProductException(ErrorCode.SELLER_ROLE_REQUIRED);
-    }
   }
 }

--- a/src/main/java/com/example/dropshop/domain/product/controller/SellerImageController.java
+++ b/src/main/java/com/example/dropshop/domain/product/controller/SellerImageController.java
@@ -1,18 +1,18 @@
 package com.example.dropshop.domain.product.controller;
 
 import com.example.dropshop.common.dto.ApiResponse;
-import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
 import com.example.dropshop.domain.product.dto.request.PresignedUrlIssueRequest;
 import com.example.dropshop.domain.product.dto.response.PresignedUrlIssueResponse;
-import com.example.dropshop.domain.product.exception.ProductException;
 import com.example.dropshop.domain.product.service.ProductImageUploadService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,31 +25,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class SellerImageController {
 
   private final ProductImageUploadService productImageUploadService;
+  private final SellerAuthResolver sellerAuthResolver;
 
   /**
    * S3 Presigned URL을 발급한다.
    */
   @PostMapping("/presigned-url")
   public ResponseEntity<ApiResponse<PresignedUrlIssueResponse>> issuePresignedUrl(
-      @RequestHeader("X-SELLER-ID") Long sellerId,
-      @RequestHeader(value = "X-ROLE", required = false) String role,
+      Authentication authentication,
       @Valid @RequestBody PresignedUrlIssueRequest request
   ) {
-    validateSellerRole(role);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
 
     PresignedUrlIssueResponse response = productImageUploadService.issuePresignedUrl(
-        sellerId,
+        sellerAuth.sellerId(),
         request
     );
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.created(response));
   }
-
-  private void validateSellerRole(String role) {
-    if (role != null && !"SELLER".equalsIgnoreCase(role)) {
-      throw new ProductException(ErrorCode.SELLER_ROLE_REQUIRED);
-    }
-  }
 }
-

--- a/src/main/java/com/example/dropshop/domain/seller/service/SellerFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/seller/service/SellerFacadeService.java
@@ -1,0 +1,28 @@
+package com.example.dropshop.domain.seller.service;
+
+import com.example.dropshop.domain.seller.entity.Seller;
+import com.example.dropshop.domain.seller.repository.SellerRepository;
+import com.example.dropshop.domain.user.entity.User;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 판매자 도메인 파사드 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class SellerFacadeService {
+
+  private final SellerRepository sellerRepository;
+
+  /**
+   * 사용자 정보로 판매자 정보를 조회한다.
+   */
+  @Transactional(readOnly = true)
+  public Optional<Seller> findByUser(User user) {
+    return sellerRepository.findByUser(user);
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/user/service/UserFacadeService.java
@@ -23,5 +23,13 @@ public class UserFacadeService {
   public Optional<User> findById(Long userId) {
     return userRepository.findById(userId);
   }
+
+  /**
+   * 이메일로 사용자 정보를 조회한다.
+   */
+  @Transactional(readOnly = true)
+  public Optional<User> findByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
 }
 


### PR DESCRIPTION
## 📌 PR 제목
refactor : 판매자 인증 로직 공통화 및 JWT 기반 인증으로 전환

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

**공통 판매자 인증 컴포넌트 추가**
- `SellerAuthContext` 레코드 추가 - 판매자 인증 정보를 담는 공통 DTO
- `SellerAuthResolver` 컴포넌트 추가 - JWT 기반 판매자 인증 해석 로직 공통화

**컨트롤러 리팩토링**
- `DropsController`, `ProductController`, `SellerImageController` 에서 각각 중복으로 존재하던 판매자 인증 해석 로직 제거
- 공통 `SellerAuthResolver.resolve(Authentication)` 호출로 통일
- 불필요해진 `HttpServletRequest` 파라미터 제거

**헤더 기반 임시 인증 제거**
- JWT 필터(`JwtAuthenticationFilter`) 가 `SecurityConfig` 에 등록되어 있어 헤더 기반 폴백은 실제로 동작하지 않는 상태였음
- 동작하지 않는 헤더 폴백 로직과 관련 상수를 제거하고 JWT 인증만 사용하도록 정리

---

## 🔗 관련 이슈
- JWT 보안 설정 개선 이슈와 연관

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] `DropsControllerTest` 통과 확인
- [x] `ProductControllerTest` 통과 확인
- [x] `SellerImageControllerTest` 통과 확인
- [x] `compileJava`, `compileTestJava` 빌드 성공 확인
- [ ] Postman - `POST /api/auth/login` 으로 토큰 발급 후 `Authorization: Bearer {accessToken}` 헤더로 API 호출 테스트 필요

---

## 💡 참고 사항
- 헤더 기반 인증(`X-SELLER-ID`, `X-ROLE` 등)은 이번 PR로 완전히 제거되었습니다. 이후 테스트는 반드시 JWT 토큰을 사용해야 합니다.
- `Product/Drops` 도메인의 `sellerId` 는 현재 `Seller PK` 가 아닌 **`User PK` 기준**으로 저장되어 있습니다. JWT 인증에서 조회된 `user.getId()` 를 그대로 사용하고 있으므로 기준이 일치합니다.
- `SellerAuthResolver` 는 향후 인증 방식이 변경되더라도 이 클래스만 수정하면 되도록 설계되어 있습니다.
