### PR TITLE
test : drops 도메인 단위 테스트 및 통합 테스트 작성

### DIFF
--- a/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
@@ -1,0 +1,137 @@
+package com.example.dropshop.domain.drops.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
+import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.service.DropsFacadeService;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(DropsController.class)
+@WithMockUser(roles = "SELLER")
+class DropsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private DropsFacadeService dropsFacadeService;
+
+  @MockitoBean
+  private DropsQueryService dropsQueryService;
+
+  @MockitoBean
+  private SellerAuthResolver sellerAuthResolver;
+
+  @Test
+  @DisplayName("드랍 생성 성공")
+  void createDrop_success() throws Exception {
+    DropCreateRequest request = new DropCreateRequest();
+    ReflectionTestUtils.setField(request, "productId", 1L);
+    ReflectionTestUtils.setField(request, "startAt", LocalDateTime.of(2026, 4, 25, 12, 0));
+    ReflectionTestUtils.setField(request, "endAt", LocalDateTime.of(2026, 4, 26, 12, 0));
+    ReflectionTestUtils.setField(request, "totalStock", 30L);
+    ReflectionTestUtils.setField(request, "purchaseLimit", 1L);
+    ReflectionTestUtils.setField(request, "useQueue", true);
+
+    DropResponse response = DropResponse.builder()
+        .dropId(10L)
+        .productId(1L)
+        .status("SCHEDULED")
+        .startAt(LocalDateTime.of(2026, 4, 25, 12, 0))
+        .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
+        .totalStock(30L)
+        .remainStock(30L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .createdAt(LocalDateTime.of(2026, 4, 20, 10, 0))
+        .modifiedAt(LocalDateTime.of(2026, 4, 20, 10, 0))
+        .build();
+
+    given(sellerAuthResolver.resolve(any()))
+        .willReturn(new SellerAuthContext(1L, true, true));
+    given(dropsFacadeService.createSellerDrop(eq(1L), eq(true), eq(true), any(DropCreateRequest.class)))
+        .willReturn(response);
+
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.code").value(201))
+        .andExpect(jsonPath("$.data.dropId").value(10L))
+        .andExpect(jsonPath("$.data.productId").value(1L))
+        .andExpect(jsonPath("$.data.status").value("SCHEDULED"));
+  }
+
+  @Test
+  @DisplayName("드랍 강제 종료 성공")
+  void stopDrop_success() throws Exception {
+    DropResponse response = DropResponse.builder()
+        .dropId(10L)
+        .productId(1L)
+        .status("FINISHED")
+        .startAt(LocalDateTime.of(2026, 4, 25, 12, 0))
+        .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
+        .totalStock(30L)
+        .remainStock(12L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .createdAt(LocalDateTime.of(2026, 4, 20, 10, 0))
+        .modifiedAt(LocalDateTime.of(2026, 4, 20, 10, 30))
+        .build();
+
+    given(sellerAuthResolver.resolve(any()))
+        .willReturn(new SellerAuthContext(1L, true, true));
+    given(dropsFacadeService.stopSellerDrop(10L, 1L, true, true)).willReturn(response);
+
+    mockMvc.perform(patch("/api/sellers/drops/{id}/stop", 10L)
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.dropId").value(10L))
+        .andExpect(jsonPath("$.data.status").value("FINISHED"));
+  }
+
+  @Test
+  @DisplayName("SELLER 권한이 없으면 드랍 생성이 거부된다")
+  @WithAnonymousUser
+  void createDrop_unauthorized_forbidden() throws Exception {
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content("{}"))
+        .andExpect(status().isForbidden());
+  }
+}
+
+

--- a/src/test/java/com/example/dropshop/domain/drops/controller/DropsQueryControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/DropsQueryControllerTest.java
@@ -1,0 +1,99 @@
+package com.example.dropshop.domain.drops.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DropsQueryController.class)
+class DropsQueryControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private DropsQueryService dropsQueryService;
+
+  @Test
+  @DisplayName("공개 드롭 목록 조회 성공")
+  void getPublicDrops_success() throws Exception {
+    DropListItemResponse item = DropListItemResponse.builder()
+        .dropId(10L)
+        .productId(1L)
+        .productName("테스트 상품")
+        .thumbnailUrl("https://example.com/thumb.jpg")
+        .status("ACTIVE")
+        .startAt(LocalDateTime.of(2026, 4, 25, 12, 0))
+        .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
+        .soldCount(5L)
+        .remainStock(25L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .build();
+
+    Page<DropListItemResponse> page = new PageImpl<>(
+        List.of(item),
+        PageRequest.of(0, 20),
+        1
+    );
+
+    given(dropsQueryService.findPublicDrops(eq(DropsStatus.ACTIVE), any())).willReturn(page);
+
+    mockMvc.perform(get("/api/drops")
+            .param("status", "ACTIVE")
+            .param("page", "0")
+            .param("size", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.content[0].dropId").value(10L))
+        .andExpect(jsonPath("$.data.content[0].status").value("ACTIVE"))
+        .andExpect(jsonPath("$.data.content[0].soldCount").value(5L));
+  }
+
+  @Test
+  @DisplayName("공개 드롭 상세 조회 성공")
+  void getDropDetail_success() throws Exception {
+    DropResponse response = DropResponse.builder()
+        .dropId(10L)
+        .productId(1L)
+        .status("ACTIVE")
+        .startAt(LocalDateTime.of(2026, 4, 25, 12, 0))
+        .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
+        .totalStock(30L)
+        .remainStock(25L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .build();
+
+    given(dropsQueryService.findPublicDropDetail(10L)).willReturn(response);
+
+    mockMvc.perform(get("/api/drops/{dropId}", 10L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.dropId").value(10L))
+        .andExpect(jsonPath("$.data.useQueue").value(true));
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryControllerTest.java
@@ -1,0 +1,71 @@
+package com.example.dropshop.domain.drops.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProductDropsQueryController.class)
+class ProductDropsQueryControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private DropsQueryService dropsQueryService;
+
+  @Test
+  @DisplayName("상품별 드롭 이력 조회 성공")
+  void getDropsByProduct_success() throws Exception {
+    DropListItemResponse item = DropListItemResponse.builder()
+        .dropId(10L)
+        .productId(1L)
+        .productName("테스트 상품")
+        .thumbnailUrl("https://example.com/thumb.jpg")
+        .status("FINISHED")
+        .startAt(LocalDateTime.of(2026, 4, 25, 12, 0))
+        .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
+        .soldCount(30L)
+        .remainStock(0L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .build();
+
+    Page<DropListItemResponse> page = new PageImpl<>(
+        List.of(item),
+        PageRequest.of(0, 20),
+        1
+    );
+
+    given(dropsQueryService.findDropsByProduct(eq(1L), any())).willReturn(page);
+
+    mockMvc.perform(get("/api/products/{productId}/drops", 1L)
+            .param("page", "0")
+            .param("size", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.content[0].dropId").value(10L))
+        .andExpect(jsonPath("$.data.content[0].soldCount").value(30L));
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/repository/DropsRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/repository/DropsRepositoryIntegrationTest.java
@@ -1,0 +1,269 @@
+package com.example.dropshop.domain.drops.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.dropshop.common.config.QuerydslConfig;
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.repository.ProductRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest(properties = {
+    "spring.datasource.url=jdbc:h2:mem:drops-test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+    "spring.sql.init.mode=never"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QuerydslConfig.class)
+class DropsRepositoryIntegrationTest {
+
+  @Autowired
+  private DropsRepository dropsRepository;
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @Autowired
+  private EntityManager entityManager;
+
+  @Test
+  @DisplayName("상태 필터로 공개 드랍 목록을 페이징 조회한다")
+  void findAllByStatusIn_filtersCorrectly() {
+    Product product = saveProduct(1L);
+
+    Drops scheduled = saveDrop(product, DropsStatus.SCHEDULED,
+        LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2));
+    Drops active = saveDrop(product, DropsStatus.ACTIVE,
+        LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(2));
+    Drops finished = saveDrop(product, DropsStatus.FINISHED,
+        LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(1));
+
+    Page<Drops> result = dropsRepository.findAllByStatusIn(
+        EnumSet.of(DropsStatus.SCHEDULED, DropsStatus.ACTIVE),
+        PageRequest.of(0, 10)
+    );
+
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .containsExactlyInAnyOrder(scheduled.getId(), active.getId());
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .doesNotContain(finished.getId());
+  }
+
+  @Test
+  @DisplayName("findAllByStatusIn 조회 시 Product를 eager loading한다")
+  void findAllByStatusIn_loadsProductEagerly() {
+    Product product = saveProduct(1L);
+    saveDrop(product, DropsStatus.ACTIVE,
+        LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(2));
+
+    entityManager.clear();
+
+    Page<Drops> result = dropsRepository.findAllByStatusIn(
+        EnumSet.of(DropsStatus.ACTIVE),
+        PageRequest.of(0, 10)
+    );
+
+    PersistenceUnitUtil persistenceUnitUtil =
+        entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+    Drops loaded = result.getContent().get(0);
+    assertThat(persistenceUnitUtil.isLoaded(loaded, "product")).isTrue();
+  }
+
+  @Test
+  @DisplayName("시작 시간이 도달한 SCHEDULED 드랍을 조회한다")
+  void findAllByStatusAndStartAtLessThanEqual_returnsReadyDrops() {
+    Product product = saveProduct(1L);
+    LocalDateTime now = LocalDateTime.now();
+
+    Drops ready = saveDrop(product, DropsStatus.SCHEDULED,
+        now.minusMinutes(10), now.plusDays(1));
+    Drops notYet = saveDrop(product, DropsStatus.SCHEDULED,
+        now.plusHours(1), now.plusDays(1));
+
+    List<Drops> result = dropsRepository.findAllByStatusAndStartAtLessThanEqual(
+        DropsStatus.SCHEDULED, now
+    );
+
+    assertThat(result).extracting(Drops::getId).containsExactly(ready.getId());
+    assertThat(result).extracting(Drops::getId).doesNotContain(notYet.getId());
+  }
+
+  @Test
+  @DisplayName("종료 시간 초과 또는 재고 소진된 ACTIVE 드랍을 단일 쿼리로 조회한다")
+  void findAllActiveDropsToFinish_returnsExpiredAndSoldOut() {
+    Product product = saveProduct(1L);
+    LocalDateTime now = LocalDateTime.now();
+
+    Drops expired = saveDrop(product, DropsStatus.ACTIVE,
+        now.minusDays(2), now.minusMinutes(1));
+    Drops soldOut = saveSoldOutDrop(product, DropsStatus.ACTIVE,
+        now.minusHours(1), now.plusHours(1));
+    Drops ongoing = saveDrop(product, DropsStatus.ACTIVE,
+        now.minusHours(1), now.plusHours(1));
+
+    List<Drops> result = dropsRepository.findAllActiveDropsToFinish(DropsStatus.ACTIVE, now);
+
+    assertThat(result).extracting(Drops::getId)
+        .containsExactlyInAnyOrder(expired.getId(), soldOut.getId());
+    assertThat(result).extracting(Drops::getId).doesNotContain(ongoing.getId());
+  }
+
+  @Test
+  @DisplayName("판매자 ID로 본인 드랍 목록을 조회한다")
+  void findSellerDropsBySellerId_returnsOnlySellerDrops() {
+    Product myProduct = saveProduct(1L);
+    Product otherProduct = saveProduct(2L);
+
+    Drops myDrop1 = saveDrop(myProduct, DropsStatus.FINISHED,
+        LocalDateTime.now().minusDays(3), LocalDateTime.now().minusDays(2));
+    Drops myDrop2 = saveDrop(myProduct, DropsStatus.SCHEDULED,
+        LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2));
+    Drops otherDrop = saveDrop(otherProduct, DropsStatus.ACTIVE,
+        LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(2));
+
+    Page<Drops> result = dropsRepository.findSellerDropsBySellerId(1L, PageRequest.of(0, 10));
+
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .containsExactlyInAnyOrder(myDrop1.getId(), myDrop2.getId());
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .doesNotContain(otherDrop.getId());
+  }
+
+  @Test
+  @DisplayName("특정 상품의 드랍 이력을 공개 상태로 필터링하여 조회한다")
+  void findAllByProductIdAndStatusIn_filtersCorrectly() {
+    Product product = saveProduct(1L);
+
+    Drops active = saveDrop(product, DropsStatus.ACTIVE,
+        LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(2));
+    Drops finished = saveDrop(product, DropsStatus.FINISHED,
+        LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(1));
+    Drops scheduled = saveDrop(product, DropsStatus.SCHEDULED,
+        LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2));
+
+    Page<Drops> result = dropsRepository.findAllByProductIdAndStatusIn(
+        product.getId(),
+        EnumSet.of(DropsStatus.ACTIVE, DropsStatus.FINISHED),
+        PageRequest.of(0, 10)
+    );
+
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .containsExactlyInAnyOrder(active.getId(), finished.getId());
+    assertThat(result.getContent()).extracting(Drops::getId)
+        .doesNotContain(scheduled.getId());
+  }
+
+  @Test
+  @DisplayName("특정 상품의 최신 드랍 1건을 시작 시간 기준 내림차순으로 조회한다")
+  void findTopByProductIdOrderByStartAtDesc_returnsLatest() {
+    Product product = saveProduct(1L);
+    LocalDateTime now = LocalDateTime.now();
+
+    saveDrop(product, DropsStatus.FINISHED,
+        now.minusDays(5), now.minusDays(4));
+    Drops latest = saveDrop(product, DropsStatus.SCHEDULED,
+        now.plusDays(1), now.plusDays(2));
+
+    Optional<Drops> result = dropsRepository.findTopByProductIdOrderByStartAtDesc(product.getId());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getId()).isEqualTo(latest.getId());
+  }
+
+  @Test
+  @DisplayName("진행 중 상태 드랍 존재 여부를 확인한다")
+  void existsByProductIdAndStatusIn_returnsTrue() {
+    Product product = saveProduct(1L);
+    saveDrop(product, DropsStatus.ACTIVE,
+        LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(2));
+
+    boolean exists = dropsRepository.existsByProductIdAndStatusIn(
+        product.getId(),
+        EnumSet.of(DropsStatus.SCHEDULED, DropsStatus.ACTIVE)
+    );
+
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  @DisplayName("진행 중 드랍이 없으면 존재 여부가 false를 반환한다")
+  void existsByProductIdAndStatusIn_returnsFalse() {
+    Product product = saveProduct(1L);
+    saveDrop(product, DropsStatus.FINISHED,
+        LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(1));
+
+    boolean exists = dropsRepository.existsByProductIdAndStatusIn(
+        product.getId(),
+        EnumSet.of(DropsStatus.SCHEDULED, DropsStatus.ACTIVE)
+    );
+
+    assertThat(exists).isFalse();
+  }
+
+  private Product saveProduct(Long sellerId) {
+    Product product = Product.create(
+        sellerId,
+        "테스트 상품",
+        "SHOES",
+        new BigDecimal("100000"),
+        10,
+        100,
+        "https://cdn.example.com/thumb.jpg",
+        "설명",
+        "스펙",
+        "배송 정책",
+        "환불 정책"
+    );
+    return productRepository.saveAndFlush(product);
+  }
+
+  private Drops saveDrop(
+      Product product,
+      DropsStatus status,
+      LocalDateTime startAt,
+      LocalDateTime endAt
+  ) {
+    Drops drops = Drops.create(product, startAt, endAt, 10L, 1L, true);
+    if (status == DropsStatus.ACTIVE) {
+      drops.activate();
+    } else if (status == DropsStatus.FINISHED) {
+      drops.activate();
+      drops.finish();
+    }
+    return dropsRepository.saveAndFlush(drops);
+  }
+
+  private Drops saveSoldOutDrop(
+      Product product,
+      DropsStatus status,
+      LocalDateTime startAt,
+      LocalDateTime endAt
+  ) {
+    Drops drops = Drops.create(product, startAt, endAt, 10L, 1L, true);
+    if (status == DropsStatus.ACTIVE) {
+      drops.activate();
+    }
+    drops.decrementRemainStock(10L);
+    return dropsRepository.saveAndFlush(drops);
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/scheduler/DropsStatusSchedulerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/scheduler/DropsStatusSchedulerTest.java
@@ -1,0 +1,49 @@
+package com.example.dropshop.domain.drops.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.dropshop.domain.drops.service.DropsStatusTransitionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DropsStatusSchedulerTest {
+
+  @Mock
+  private DropsStatusTransitionService dropsStatusTransitionService;
+
+  @Mock
+  private DropsSchedulerProperties dropsSchedulerProperties;
+
+  @InjectMocks
+  private DropsStatusScheduler dropsStatusScheduler;
+
+  @Test
+  @DisplayName("스케줄러 비활성화 시 상태 전이 서비스를 호출하지 않는다")
+  void transitionDropsStatus_disabled_skip() {
+    org.mockito.BDDMockito.given(dropsSchedulerProperties.isEnabled()).willReturn(false);
+
+    dropsStatusScheduler.transitionDropsStatus();
+
+    verify(dropsStatusTransitionService, never()).transitionScheduledToActive(any());
+    verify(dropsStatusTransitionService, never()).transitionActiveToFinished(any());
+  }
+
+  @Test
+  @DisplayName("스케줄러 활성화 시 상태 전이 서비스를 순차 호출한다")
+  void transitionDropsStatus_enabled_callsServices() {
+    org.mockito.BDDMockito.given(dropsSchedulerProperties.isEnabled()).willReturn(true);
+
+    dropsStatusScheduler.transitionDropsStatus();
+
+    verify(dropsStatusTransitionService).transitionScheduledToActive(any());
+    verify(dropsStatusTransitionService).transitionActiveToFinished(any());
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
@@ -3,7 +3,6 @@ package com.example.dropshop.domain.drops.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -15,7 +14,7 @@ import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.exception.DropsException;
-import com.example.dropshop.domain.order.facade.OrderFacadeService;
+import com.example.dropshop.domain.order.service.OrderHistoryQueryService;
 import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
@@ -40,7 +39,7 @@ class DropsFacadeServiceTest {
   private ProductDomainFacadeService productDomainFacadeService;
 
   @Mock
-  private OrderFacadeService orderFacadeService;
+  private OrderHistoryQueryService orderHistoryQueryService;
 
   @InjectMocks
   private DropsFacadeService dropsFacadeService;
@@ -71,7 +70,7 @@ class DropsFacadeServiceTest {
     ReflectionTestUtils.setField(drops, "status", DropsStatus.SCHEDULED);
 
     given(dropsService.findById(10L)).willReturn(drops);
-    given(orderFacadeService.existsOrderHistoryForDrop(10L)).willReturn(true);
+    given(orderHistoryQueryService.existsOrderHistoryForDrop(10L)).willReturn(true);
 
     assertThatThrownBy(() -> dropsFacadeService.deleteSellerDrop(10L, 1L, true, true))
         .isInstanceOf(DropsException.class)

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
@@ -1,0 +1,195 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.exception.DropsException;
+import com.example.dropshop.domain.order.facade.OrderFacadeService;
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DropsFacadeServiceTest {
+
+  @Mock
+  private DropsService dropsService;
+
+  @Mock
+  private ProductDomainFacadeService productDomainFacadeService;
+
+  @Mock
+  private OrderFacadeService orderFacadeService;
+
+  @InjectMocks
+  private DropsFacadeService dropsFacadeService;
+
+  @Test
+  @DisplayName("판매자 드랍 생성 성공 시 상품 상태를 READY로 변경한다")
+  void createSellerDrop_success() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    DropCreateRequest request = createDropCreateRequest(product.getId());
+
+    given(productDomainFacadeService.findOwnedProduct(product.getId(), 1L)).willReturn(product);
+    given(dropsService.existsOngoingDropForProduct(product.getId())).willReturn(false);
+    given(dropsService.create(product, request)).willReturn(drops);
+
+    DropResponse response = dropsFacadeService.createSellerDrop(1L, true, true, request);
+
+    assertThat(response.getProductId()).isEqualTo(product.getId());
+    assertThat(response.getStatus()).isEqualTo("SCHEDULED");
+    verify(productDomainFacadeService).updateStatusByDrop(product, ProductStatus.READY);
+  }
+
+  @Test
+  @DisplayName("주문 이력이 있는 드랍은 삭제할 수 없다")
+  void deleteSellerDrop_withOrderHistory_throwsException() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.SCHEDULED);
+
+    given(dropsService.findById(10L)).willReturn(drops);
+    given(orderFacadeService.existsOrderHistoryForDrop(10L)).willReturn(true);
+
+    assertThatThrownBy(() -> dropsFacadeService.deleteSellerDrop(10L, 1L, true, true))
+        .isInstanceOf(DropsException.class)
+        .hasMessage(ErrorCode.DROP_DELETE_NOT_ALLOWED.getMessage());
+
+    verify(dropsService, never()).delete(any(Drops.class));
+    verify(productDomainFacadeService, never()).updateStatusByDrop(any(Product.class), any(ProductStatus.class));
+  }
+
+  @Test
+  @DisplayName("판매자 드랍 강제 종료 성공 시 상품 상태를 OUT_OF_STOCK으로 변경한다")
+  void stopSellerDrop_success() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.ACTIVE);
+
+    given(dropsService.findById(10L)).willReturn(drops);
+
+    DropResponse response = dropsFacadeService.stopSellerDrop(10L, 1L, true, true);
+
+    assertThat(response.getStatus()).isEqualTo("FINISHED");
+    verify(productDomainFacadeService).updateStatusByDrop(product, ProductStatus.OUT_OF_STOCK);
+  }
+
+  @Test
+  @DisplayName("주문 생성 시 ACTIVE 드랍 재고가 차감된다")
+  void reserveStockForOrder_success() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.ACTIVE);
+    ReflectionTestUtils.setField(drops, "remainStock", 5L);
+
+    given(dropsService.findById(10L)).willReturn(drops);
+
+    Drops result = dropsFacadeService.reserveStockForOrder(10L, 1L, 1);
+
+    assertThat(result.getRemainStock()).isEqualTo(4L);
+    verify(productDomainFacadeService, never()).updateStatusByDrop(any(Product.class), any(ProductStatus.class));
+  }
+
+  @Test
+  @DisplayName("드랍 종료 상태에서 재고 복원 시 ACTIVE로 재전환된다")
+  void restoreStockForOrder_reactivateSuccess() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.FINISHED);
+    ReflectionTestUtils.setField(drops, "remainStock", 0L);
+
+    given(dropsService.findById(10L)).willReturn(drops);
+
+    dropsFacadeService.restoreStockForOrder(10L, 1);
+
+    assertThat(drops.isActive()).isTrue();
+    assertThat(drops.getRemainStock()).isEqualTo(1L);
+    verify(productDomainFacadeService).updateStatusByDrop(product, ProductStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("재고 복원 후 재활성화 중 동시성 충돌이 발생해도 예외를 전파하지 않는다")
+  void restoreStockForOrder_optimisticLockIgnore() {
+    Product product = createProduct(1L);
+    Drops drops = createDrop(product);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.FINISHED);
+    ReflectionTestUtils.setField(drops, "remainStock", 0L);
+
+    given(dropsService.findById(10L)).willReturn(drops);
+    doThrow(new OptimisticLockingFailureException("conflict"))
+        .when(productDomainFacadeService)
+        .updateStatusByDrop(product, ProductStatus.ON_SALE);
+
+    dropsFacadeService.restoreStockForOrder(10L, 1);
+
+    assertThat(drops.getRemainStock()).isEqualTo(1L);
+  }
+
+  private Product createProduct(Long sellerId) {
+    Product product = Product.create(
+        sellerId,
+        "한정판 스니커즈",
+        "SHOES",
+        new BigDecimal("250000"),
+        10,
+        100,
+        "https://cdn.example.com/thumb.jpg",
+        "<p>상품 설명</p>",
+        "사이즈: 255",
+        "배송 안내",
+        "환불 정책"
+    );
+    ReflectionTestUtils.setField(product, "id", 1L);
+    return product;
+  }
+
+  private Drops createDrop(Product product) {
+    Drops drops = Drops.create(
+        product,
+        LocalDateTime.now().plusDays(1),
+        LocalDateTime.now().plusDays(2),
+        30L,
+        1L,
+        true
+    );
+    ReflectionTestUtils.setField(drops, "id", 10L);
+    return drops;
+  }
+
+  private DropCreateRequest createDropCreateRequest(Long productId) {
+    DropCreateRequest request = new DropCreateRequest();
+    ReflectionTestUtils.setField(request, "productId", productId);
+    ReflectionTestUtils.setField(request, "startAt", LocalDateTime.now().plusDays(1));
+    ReflectionTestUtils.setField(request, "endAt", LocalDateTime.now().plusDays(2));
+    ReflectionTestUtils.setField(request, "totalStock", 30L);
+    ReflectionTestUtils.setField(request, "purchaseLimit", 1L);
+    ReflectionTestUtils.setField(request, "useQueue", true);
+    return request;
+  }
+}
+
+
+
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsQueryServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsQueryServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.repository.DropsRepository;
+import com.example.dropshop.domain.product.entity.Product;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DropsQueryServiceTest {
+
+  @Mock
+  private DropsRepository dropsRepository;
+
+  @InjectMocks
+  private DropsQueryService dropsQueryService;
+
+  @Test
+  @DisplayName("공개 드롭 목록 조회 성공")
+  void findPublicDrops_success() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+    Page<Drops> page = new PageImpl<>(List.of(drop), PageRequest.of(0, 20), 1);
+
+    given(dropsRepository.findAllByStatusIn(any(), any(Pageable.class))).willReturn(page);
+
+    Page<DropListItemResponse> result = dropsQueryService.findPublicDrops(
+        null,
+        PageRequest.of(0, 20)
+    );
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getContent().get(0).getDropId()).isEqualTo(10L);
+    assertThat(result.getContent().get(0).getStatus()).isEqualTo("ACTIVE");
+    assertThat(result.getContent().get(0).getSoldCount()).isEqualTo(0L);
+  }
+
+  @Test
+  @DisplayName("판매자 본인 드롭 목록 조회 성공")
+  void findSellerDrops_success() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.SCHEDULED);
+    Page<Drops> page = new PageImpl<>(List.of(drop), PageRequest.of(0, 20), 1);
+
+    given(dropsRepository.findSellerDropsBySellerId(
+        eq(1L),
+        any(Pageable.class)
+    )).willReturn(page);
+
+    Page<DropListItemResponse> result = dropsQueryService.findSellerDrops(1L, PageRequest.of(0, 20));
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getContent().get(0).getProductName()).isEqualTo("테스트 상품");
+  }
+
+  @Test
+  @DisplayName("상품별 드롭 이력 조회 성공")
+  void findDropsByProduct_success() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.FINISHED);
+    Page<Drops> page = new PageImpl<>(List.of(drop), PageRequest.of(0, 20), 1);
+
+    given(dropsRepository.findAllByProductIdAndStatusIn(eq(1L), any(), any(Pageable.class)))
+        .willReturn(page);
+
+    Page<DropListItemResponse> result = dropsQueryService.findDropsByProduct(1L, PageRequest.of(0, 20));
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getContent().get(0).getStatus()).isEqualTo("FINISHED");
+  }
+
+  private Product createProduct(Long sellerId) {
+    Product product = Product.create(
+        sellerId,
+        "테스트 상품",
+        "TEST",
+        new BigDecimal("100000"),
+        10,
+        100,
+        "https://example.com/thumb.jpg",
+        "상품 설명",
+        "상품 상세",
+        "배송 안내",
+        "환불 정책"
+    );
+    ReflectionTestUtils.setField(product, "id", 1L);
+    return product;
+  }
+
+  private Drops createDrop(Product product, DropsStatus status) {
+    Drops drops = Drops.create(
+        product,
+        LocalDateTime.now().plusDays(1),
+        LocalDateTime.now().plusDays(2),
+        30L,
+        1L,
+        true
+    );
+    ReflectionTestUtils.setField(drops, "id", 10L);
+    ReflectionTestUtils.setField(drops, "status", status);
+    return drops;
+  }
+}
+
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsServiceTest.java
@@ -1,0 +1,186 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
+import com.example.dropshop.domain.drops.dto.request.DropUpdateRequest;
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.exception.DropsException;
+import com.example.dropshop.domain.drops.repository.DropsRepository;
+import com.example.dropshop.domain.product.entity.Product;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DropsServiceTest {
+
+  @Mock
+  private DropsRepository dropsRepository;
+
+  @InjectMocks
+  private DropsService dropsService;
+
+  @Test
+  @DisplayName("드랍 생성 성공")
+  void create_success() {
+    // given
+    Product product = createProduct(1L, 100);
+    DropCreateRequest request = createDropCreateRequest(
+        product.getId(),
+        LocalDateTime.now().plusDays(1),
+        LocalDateTime.now().plusDays(2),
+        30L,
+        1L,
+        true
+    );
+
+    given(dropsRepository.save(any(Drops.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    Drops saved = dropsService.create(product, request);
+
+    // then
+    assertThat(saved.getProduct()).isEqualTo(product);
+    assertThat(saved.getStatus()).isEqualTo(DropsStatus.SCHEDULED);
+    assertThat(saved.getTotalStock()).isEqualTo(30L);
+    assertThat(saved.getRemainStock()).isEqualTo(30L);
+    assertThat(saved.getPurchaseLimit()).isEqualTo(1L);
+    assertThat(saved.isUseQueue()).isTrue();
+  }
+
+  @Test
+  @DisplayName("진행 중인 드랍은 시작 시간과 총 판매 수량 수정이 불가능하다")
+  void update_activeDropStartAtOrTotalStock_throwsException() {
+    // given
+    Drops drops = createDrop(createProduct(1L, 100), 20L, 20L);
+    drops.activate();
+    DropUpdateRequest request = createDropUpdateRequest(
+        LocalDateTime.now().plusDays(3),
+        null,
+        null,
+        null,
+        null
+    );
+
+    // when & then
+    assertThatThrownBy(() -> dropsService.update(drops, 100, request))
+        .isInstanceOf(DropsException.class)
+        .hasMessage(ErrorCode.DROP_ACTIVE_UPDATE_LOCKED.getMessage());
+  }
+
+  @Test
+  @DisplayName("이미 판매된 수량보다 작은 총 판매 수량으로는 수정할 수 없다")
+  void update_totalStockLessThanSoldCount_throwsException() {
+    // given
+    Drops drops = createDrop(createProduct(1L, 100), 10L, 8L);
+    DropUpdateRequest request = createDropUpdateRequest(
+        null,
+        LocalDateTime.now().plusDays(3),
+        1L,
+        1L,
+        false
+    );
+
+    // when & then
+    assertThatThrownBy(() -> dropsService.update(drops, 100, request))
+        .isInstanceOf(DropsException.class)
+        .hasMessage(ErrorCode.INVALID_DROP_REMAIN_STOCK.getMessage());
+  }
+
+  @Test
+  @DisplayName("종료 대상 ACTIVE 드랍은 단일 쿼리로 조회한다")
+  void findActiveDropsToFinish_success() {
+    // given
+    LocalDateTime baseTime = LocalDateTime.now();
+    Drops activeDrop = createDrop(createProduct(1L, 100), 10L, 5L);
+    given(dropsRepository.findAllActiveDropsToFinish(DropsStatus.ACTIVE, baseTime))
+        .willReturn(List.of(activeDrop));
+
+    // when
+    List<Drops> result = dropsService.findActiveDropsToFinish(baseTime);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).isEqualTo(activeDrop);
+  }
+
+  private Product createProduct(Long sellerId, int stock) {
+    Product product = Product.create(
+        sellerId,
+        "한정판 스니커즈",
+        "SHOES",
+        new BigDecimal("250000"),
+        10,
+        stock,
+        "https://cdn.example.com/thumb.jpg",
+        "<p>상품 설명</p>",
+        "사이즈: 255",
+        "배송 안내",
+        "환불 정책"
+    );
+    ReflectionTestUtils.setField(product, "id", 1L);
+    return product;
+  }
+
+  private Drops createDrop(Product product, Long totalStock, Long remainStock) {
+    Drops drops = Drops.create(
+        product,
+        LocalDateTime.now().plusDays(1),
+        LocalDateTime.now().plusDays(2),
+        totalStock,
+        1L,
+        true
+    );
+    ReflectionTestUtils.setField(drops, "remainStock", remainStock);
+    return drops;
+  }
+
+  private DropCreateRequest createDropCreateRequest(
+      Long productId,
+      LocalDateTime startAt,
+      LocalDateTime endAt,
+      Long totalStock,
+      Long purchaseLimit,
+      boolean useQueue
+  ) {
+    DropCreateRequest request = new DropCreateRequest();
+    ReflectionTestUtils.setField(request, "productId", productId);
+    ReflectionTestUtils.setField(request, "startAt", startAt);
+    ReflectionTestUtils.setField(request, "endAt", endAt);
+    ReflectionTestUtils.setField(request, "totalStock", totalStock);
+    ReflectionTestUtils.setField(request, "purchaseLimit", purchaseLimit);
+    ReflectionTestUtils.setField(request, "useQueue", useQueue);
+    return request;
+  }
+
+  private DropUpdateRequest createDropUpdateRequest(
+      LocalDateTime startAt,
+      LocalDateTime endAt,
+      Long totalStock,
+      Long purchaseLimit,
+      Boolean useQueue
+  ) {
+    DropUpdateRequest request = new DropUpdateRequest();
+    ReflectionTestUtils.setField(request, "startAt", startAt);
+    ReflectionTestUtils.setField(request, "endAt", endAt);
+    ReflectionTestUtils.setField(request, "totalStock", totalStock);
+    ReflectionTestUtils.setField(request, "purchaseLimit", purchaseLimit);
+    ReflectionTestUtils.setField(request, "useQueue", useQueue);
+    return request;
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
@@ -1,0 +1,109 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DropsStatusTransitionServiceTest {
+
+  @Mock
+  private DropsService dropsService;
+
+  @Mock
+  private ProductDomainFacadeService productDomainFacadeService;
+
+  @InjectMocks
+  private DropsStatusTransitionService dropsStatusTransitionService;
+
+  @Test
+  @DisplayName("예정 드랍을 활성 상태로 전이하고 상품을 ON_SALE로 동기화한다")
+  void transitionScheduledToActive_success() {
+    LocalDateTime now = LocalDateTime.now();
+    Drops scheduled = createDrop(1L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
+
+    given(dropsService.findScheduledDropsToActivate(any(LocalDateTime.class)))
+        .willReturn(List.of(scheduled));
+
+    int transitioned = dropsStatusTransitionService.transitionScheduledToActive(now);
+
+    assertThat(transitioned).isEqualTo(1);
+    assertThat(scheduled.isActive()).isTrue();
+    verify(productDomainFacadeService).updateStatusByDrop(scheduled.getProduct(), ProductStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("상태 전이 중 동시성 예외가 발생해도 다음 드랍 처리를 계속한다")
+  void transitionScheduledToActive_optimisticLockContinue() {
+    LocalDateTime now = LocalDateTime.now();
+    Drops first = createDrop(1L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
+    Drops second = createDrop(2L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
+
+    given(dropsService.findScheduledDropsToActivate(any(LocalDateTime.class)))
+        .willReturn(List.of(first, second));
+    doThrow(new org.springframework.dao.OptimisticLockingFailureException("conflict"))
+        .when(productDomainFacadeService)
+        .updateStatusByDrop(eq(first.getProduct()), eq(ProductStatus.ON_SALE));
+
+    int transitioned = dropsStatusTransitionService.transitionScheduledToActive(now);
+
+    assertThat(transitioned).isEqualTo(1);
+    verify(productDomainFacadeService).updateStatusByDrop(second.getProduct(), ProductStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("종료 대상 ACTIVE 드랍을 FINISHED로 전이하고 상품을 OUT_OF_STOCK으로 동기화한다")
+  void transitionActiveToFinished_success() {
+    LocalDateTime now = LocalDateTime.now();
+    Drops active = createDrop(2L, 1L, LocalDateTime.now().minusDays(1), LocalDateTime.now().minusMinutes(1));
+    active.activate();
+
+    given(dropsService.findActiveDropsToFinish(eq(now))).willReturn(List.of(active));
+
+    int transitioned = dropsStatusTransitionService.transitionActiveToFinished(now);
+
+    assertThat(transitioned).isEqualTo(1);
+    assertThat(active.isFinished()).isTrue();
+    verify(productDomainFacadeService).updateStatusByDrop(active.getProduct(), ProductStatus.OUT_OF_STOCK);
+  }
+
+  private Drops createDrop(Long dropId, Long sellerId, LocalDateTime startAt, LocalDateTime endAt) {
+    Product product = Product.create(
+        sellerId,
+        "테스트 상품",
+        "TEST",
+        new BigDecimal("100000"),
+        10,
+        100,
+        "https://example.com/thumb.jpg",
+        "상품 설명",
+        "상품 상세",
+        "배송 안내",
+        "환불 정책"
+    );
+    ReflectionTestUtils.setField(product, "id", 100L + dropId);
+
+    Drops drops = Drops.create(product, startAt, endAt, 10L, 1L, false);
+    ReflectionTestUtils.setField(drops, "id", dropId);
+    return drops;
+  }
+}
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 import com.example.dropshop.domain.drops.entity.Drops;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +59,7 @@ class DropsStatusTransitionServiceTest {
     Drops first = createDrop(1L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
     Drops second = createDrop(2L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
 
-    given(dropsService.findScheduledDropsToActivate(any(LocalDateTime.class)))
+    given(dropsService.findScheduledDropsToActivate(eq(now)))
         .willReturn(List.of(first, second));
     doThrow(new org.springframework.dao.OptimisticLockingFailureException("conflict"))
         .when(productDomainFacadeService)
@@ -66,7 +68,15 @@ class DropsStatusTransitionServiceTest {
     int transitioned = dropsStatusTransitionService.transitionScheduledToActive(now);
 
     assertThat(transitioned).isEqualTo(1);
-    verify(productDomainFacadeService).updateStatusByDrop(second.getProduct(), ProductStatus.ON_SALE);
+    // baseTime 정확성 검증
+    verify(dropsService).findScheduledDropsToActivate(eq(now));
+
+    // 호출 순서 검증: 첫 드랍 예외 → 두 번째 드랍 성공 순서
+    var inOrder = inOrder(productDomainFacadeService);
+    inOrder.verify(productDomainFacadeService)
+        .updateStatusByDrop(first.getProduct(), ProductStatus.ON_SALE);
+    inOrder.verify(productDomainFacadeService)
+        .updateStatusByDrop(second.getProduct(), ProductStatus.ON_SALE);
   }
 
   @Test


### PR DESCRIPTION
## 📌 PR 제목
test: Drops 도메인 단위 테스트 및 통합 테스트 작성

---

## ✨ 변경 사항

### 단위 테스트 (Unit Test)
- `DropsServiceTest`: 드랍 생성 / 수정 / 조회 서비스 로직 검증
  - ACTIVE 상태 드랍의 startAt · totalStock 수정 차단 검증
  - 이미 판매된 수량보다 작은 totalStock 수정 차단 검증
  - 종료 대상 ACTIVE 드랍 단일 쿼리 조회 검증
- `DropsFacadeServiceTest`: 드랍 생성 · 삭제 · 강제 종료 · 재고 연동 검증
  - 드랍 생성 성공 시 상품 상태 READY 전환 검증
  - 주문 이력 있는 드랍 삭제 차단 검증
  - 강제 종료 시 상품 상태 OUT_OF_STOCK 전환 검증
  - 재고 차감 / 복원 및 복원 후 ACTIVE 재전환 검증
  - 재활성화 중 낙관적 락 충돌 발생 시 예외 전파 차단 검증
- `DropsQueryServiceTest`: 공개 드랍 목록 / 판매자 본인 드랍 / 상품별 드랍 이력 조회 검증
- `DropsStatusTransitionServiceTest`: 상태 자동 전이 로직 검증
  - SCHEDULED → ACTIVE 전이 및 상품 ON_SALE 동기화 검증
  - 전이 중 낙관적 락 충돌 발생 시 나머지 드랍 처리 계속 진행 검증
  - ACTIVE → FINISHED 전이 및 상품 OUT_OF_STOCK 동기화 검증
- `DropsStatusSchedulerTest`: 스케줄러 활성화 / 비활성화 시 전이 서비스 호출 여부 검증

### 슬라이스 테스트 (Controller Test)
- `DropsControllerTest`: 드랍 생성 / 강제 종료 API MockMvc 검증
  - `@WithMockUser(roles = "SELLER")` 클래스 레벨 적용
  - `@WithAnonymousUser` 인증 실패 시 403 반환 케이스 추가
  - 임시 헤더(`X-SELLER-ID`, `X-ROLE` 등) 제거, JWT 기반 인증으로 통일
- `DropsQueryControllerTest`: 공개 드랍 목록 / 상세 조회 API 응답 검증
- `ProductDropsQueryControllerTest`: 상품별 드랍 이력 조회 API 응답 검증

### 통합 테스트 (Integration Test)
- `DropsRepositoryIntegrationTest`: H2 인메모리 DB 기반 Repository 쿼리 8종 검증
  - 상태 필터 페이징 조회 및 FINISHED 제외 확인
  - `@EntityGraph` Product eager loading 검증 (`PersistenceUnitUtil.isLoaded`)
  - 시작 시간 도달 SCHEDULED 드랍 조회
  - 종료 시간 초과 OR 재고 소진 드랍 단일 OR 쿼리 조회
  - 판매자 ID 기반 본인 드랍만 필터링 조회
  - 상품별 드랍 이력 상태 필터 조회
  - 최신 드랍 1건 내림차순 조회
  - 진행 중 드랍 존재 여부 확인 (true / false)

---

## 🔗 관련 이슈
- close #(이슈 번호)

---

## 🧪 테스트
- [x] 단위 테스트 전체 통과 확인
- [x] 통합 테스트 전체 통과 확인 (H2 인메모리 DB)
- [x] 인증 실패(403) 케이스 검증 완료
- [x] 낙관적 락 동시성 예외 처리 케이스 검증 완료

---

## 💡 참고 사항
- 통합 테스트는 H2 인메모리 DB (`MODE=MySQL`) 사용, 실제 MySQL과 동일한 쿼리 동작 확인
- `@EntityGraph` eager loading 검증은 `entityManager.clear()` 후 `PersistenceUnitUtil.isLoaded()`로 지연 로딩과 구분
- 낙관적 락(`@Version`) 충돌 시 해당 드랍만 스킵하고 나머지 드랍 처리가 계속되는 동작을 검증
- Controller 테스트의 임시 헤더는 JWT 전환 이후 불필요하므로 제거하고 `@WithMockUser`로 대체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 드롭 관리 전반에 대한 테스트 범위 확대: 판매자/공개 API(생성, 중단, 목록, 상세) 검증, 저장소 쿼리 동작 확인, 스케줄러와 상태 전환 로직 검사.
  * 퍼사드·서비스 레벨에서 재고 예약/복구, 상태 변경, 예외(낙관적 락 등) 처리 시나리오 검증을 추가하여 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->