### PR TITLE
test: drops 도메인 테스트 픽스처 정합성 및 낙관적 락 검증 강화

### DIFF
--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
@@ -32,6 +32,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class DropsFacadeServiceTest {
 
+  private static final Long DEFAULT_DROP_ID = 10L;
+  private static final Long DEFAULT_PRODUCT_ID = 1L;
+
   @Mock
   private DropsService dropsService;
 
@@ -47,9 +50,10 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("판매자 드랍 생성 성공 시 상품 상태를 READY로 변경한다")
   void createSellerDrop_success() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    DropCreateRequest request = createDropCreateRequest(product.getId());
+    Drops drops = createScheduledDrop(product, now);
+    DropCreateRequest request = createDropCreateRequest(product.getId(), now);
 
     given(productDomainFacadeService.findOwnedProduct(product.getId(), 1L)).willReturn(product);
     given(dropsService.existsOngoingDropForProduct(product.getId())).willReturn(false);
@@ -65,14 +69,14 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("주문 이력이 있는 드랍은 삭제할 수 없다")
   void deleteSellerDrop_withOrderHistory_throwsException() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    ReflectionTestUtils.setField(drops, "status", DropsStatus.SCHEDULED);
+    Drops drops = createScheduledDrop(product, now);
 
-    given(dropsService.findById(10L)).willReturn(drops);
-    given(orderHistoryQueryService.existsOrderHistoryForDrop(10L)).willReturn(true);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
+    given(orderHistoryQueryService.existsOrderHistoryForDrop(DEFAULT_DROP_ID)).willReturn(true);
 
-    assertThatThrownBy(() -> dropsFacadeService.deleteSellerDrop(10L, 1L, true, true))
+    assertThatThrownBy(() -> dropsFacadeService.deleteSellerDrop(DEFAULT_DROP_ID, 1L, true, true))
         .isInstanceOf(DropsException.class)
         .hasMessage(ErrorCode.DROP_DELETE_NOT_ALLOWED.getMessage());
 
@@ -83,13 +87,13 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("판매자 드랍 강제 종료 성공 시 상품 상태를 OUT_OF_STOCK으로 변경한다")
   void stopSellerDrop_success() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    ReflectionTestUtils.setField(drops, "status", DropsStatus.ACTIVE);
+    Drops drops = createActiveDrop(product, now);
 
-    given(dropsService.findById(10L)).willReturn(drops);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
 
-    DropResponse response = dropsFacadeService.stopSellerDrop(10L, 1L, true, true);
+    DropResponse response = dropsFacadeService.stopSellerDrop(DEFAULT_DROP_ID, 1L, true, true);
 
     assertThat(response.getStatus()).isEqualTo("FINISHED");
     verify(productDomainFacadeService).updateStatusByDrop(product, ProductStatus.OUT_OF_STOCK);
@@ -98,14 +102,14 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("주문 생성 시 ACTIVE 드랍 재고가 차감된다")
   void reserveStockForOrder_success() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    ReflectionTestUtils.setField(drops, "status", DropsStatus.ACTIVE);
+    Drops drops = createActiveDrop(product, now);
     ReflectionTestUtils.setField(drops, "remainStock", 5L);
 
-    given(dropsService.findById(10L)).willReturn(drops);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
 
-    Drops result = dropsFacadeService.reserveStockForOrder(10L, 1L, 1);
+    Drops result = dropsFacadeService.reserveStockForOrder(DEFAULT_DROP_ID, 1L, 1);
 
     assertThat(result.getRemainStock()).isEqualTo(4L);
     verify(productDomainFacadeService, never()).updateStatusByDrop(any(Product.class), any(ProductStatus.class));
@@ -114,14 +118,14 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("드랍 종료 상태에서 재고 복원 시 ACTIVE로 재전환된다")
   void restoreStockForOrder_reactivateSuccess() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    ReflectionTestUtils.setField(drops, "status", DropsStatus.FINISHED);
+    Drops drops = createFinishedButReactivatableDrop(product, now);
     ReflectionTestUtils.setField(drops, "remainStock", 0L);
 
-    given(dropsService.findById(10L)).willReturn(drops);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
 
-    dropsFacadeService.restoreStockForOrder(10L, 1);
+    dropsFacadeService.restoreStockForOrder(DEFAULT_DROP_ID, 1);
 
     assertThat(drops.isActive()).isTrue();
     assertThat(drops.getRemainStock()).isEqualTo(1L);
@@ -131,19 +135,20 @@ class DropsFacadeServiceTest {
   @Test
   @DisplayName("재고 복원 후 재활성화 중 동시성 충돌이 발생해도 예외를 전파하지 않는다")
   void restoreStockForOrder_optimisticLockIgnore() {
+    LocalDateTime now = LocalDateTime.now();
     Product product = createProduct(1L);
-    Drops drops = createDrop(product);
-    ReflectionTestUtils.setField(drops, "status", DropsStatus.FINISHED);
+    Drops drops = createFinishedButReactivatableDrop(product, now);
     ReflectionTestUtils.setField(drops, "remainStock", 0L);
 
-    given(dropsService.findById(10L)).willReturn(drops);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
     doThrow(new OptimisticLockingFailureException("conflict"))
         .when(productDomainFacadeService)
         .updateStatusByDrop(product, ProductStatus.ON_SALE);
 
-    dropsFacadeService.restoreStockForOrder(10L, 1);
+    dropsFacadeService.restoreStockForOrder(DEFAULT_DROP_ID, 1);
 
     assertThat(drops.getRemainStock()).isEqualTo(1L);
+    verify(productDomainFacadeService).updateStatusByDrop(product, ProductStatus.ON_SALE);
   }
 
   private Product createProduct(Long sellerId) {
@@ -160,28 +165,61 @@ class DropsFacadeServiceTest {
         "배송 안내",
         "환불 정책"
     );
-    ReflectionTestUtils.setField(product, "id", 1L);
+    ReflectionTestUtils.setField(product, "id", DEFAULT_PRODUCT_ID);
     return product;
   }
 
-  private Drops createDrop(Product product) {
+  private Drops createDrop(
+      Product product,
+      LocalDateTime startAt,
+      LocalDateTime endAt,
+      DropsStatus status
+  ) {
     Drops drops = Drops.create(
         product,
-        LocalDateTime.now().plusDays(1),
-        LocalDateTime.now().plusDays(2),
+        startAt,
+        endAt,
         30L,
         1L,
         true
     );
-    ReflectionTestUtils.setField(drops, "id", 10L);
+    ReflectionTestUtils.setField(drops, "status", status);
+    ReflectionTestUtils.setField(drops, "id", DEFAULT_DROP_ID);
     return drops;
   }
 
-  private DropCreateRequest createDropCreateRequest(Long productId) {
+  private Drops createScheduledDrop(Product product, LocalDateTime baseTime) {
+    return createDrop(
+        product,
+        baseTime.plusDays(1),
+        baseTime.plusDays(2),
+        DropsStatus.SCHEDULED
+    );
+  }
+
+  private Drops createActiveDrop(Product product, LocalDateTime baseTime) {
+    return createDrop(
+        product,
+        baseTime.minusHours(1),
+        baseTime.plusHours(1),
+        DropsStatus.ACTIVE
+    );
+  }
+
+  private Drops createFinishedButReactivatableDrop(Product product, LocalDateTime baseTime) {
+    return createDrop(
+        product,
+        baseTime.minusDays(1),
+        baseTime.plusHours(2),
+        DropsStatus.FINISHED
+    );
+  }
+
+  private DropCreateRequest createDropCreateRequest(Long productId, LocalDateTime baseTime) {
     DropCreateRequest request = new DropCreateRequest();
     ReflectionTestUtils.setField(request, "productId", productId);
-    ReflectionTestUtils.setField(request, "startAt", LocalDateTime.now().plusDays(1));
-    ReflectionTestUtils.setField(request, "endAt", LocalDateTime.now().plusDays(2));
+    ReflectionTestUtils.setField(request, "startAt", baseTime.plusDays(1));
+    ReflectionTestUtils.setField(request, "endAt", baseTime.plusDays(2));
     ReflectionTestUtils.setField(request, "totalStock", 30L);
     ReflectionTestUtils.setField(request, "purchaseLimit", 1L);
     ReflectionTestUtils.setField(request, "useQueue", true);

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.dropshop.domain.drops.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -21,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,15 +38,16 @@ class DropsStatusTransitionServiceTest {
   @DisplayName("예정 드랍을 활성 상태로 전이하고 상품을 ON_SALE로 동기화한다")
   void transitionScheduledToActive_success() {
     LocalDateTime now = LocalDateTime.now();
-    Drops scheduled = createDrop(1L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
+    Drops scheduled = createDrop(1L, 1L, now.minusMinutes(1), now.plusDays(1));
 
-    given(dropsService.findScheduledDropsToActivate(any(LocalDateTime.class)))
+    given(dropsService.findScheduledDropsToActivate(eq(now)))
         .willReturn(List.of(scheduled));
 
     int transitioned = dropsStatusTransitionService.transitionScheduledToActive(now);
 
     assertThat(transitioned).isEqualTo(1);
     assertThat(scheduled.isActive()).isTrue();
+    verify(dropsService).findScheduledDropsToActivate(eq(now));
     verify(productDomainFacadeService).updateStatusByDrop(scheduled.getProduct(), ProductStatus.ON_SALE);
   }
 
@@ -56,8 +55,8 @@ class DropsStatusTransitionServiceTest {
   @DisplayName("상태 전이 중 동시성 예외가 발생해도 다음 드랍 처리를 계속한다")
   void transitionScheduledToActive_optimisticLockContinue() {
     LocalDateTime now = LocalDateTime.now();
-    Drops first = createDrop(1L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
-    Drops second = createDrop(2L, 1L, LocalDateTime.now().minusMinutes(1), LocalDateTime.now().plusDays(1));
+    Drops first = createDrop(1L, 1L, now.minusMinutes(1), now.plusDays(1));
+    Drops second = createDrop(2L, 1L, now.minusMinutes(1), now.plusDays(1));
 
     given(dropsService.findScheduledDropsToActivate(eq(now)))
         .willReturn(List.of(first, second));
@@ -83,7 +82,7 @@ class DropsStatusTransitionServiceTest {
   @DisplayName("종료 대상 ACTIVE 드랍을 FINISHED로 전이하고 상품을 OUT_OF_STOCK으로 동기화한다")
   void transitionActiveToFinished_success() {
     LocalDateTime now = LocalDateTime.now();
-    Drops active = createDrop(2L, 1L, LocalDateTime.now().minusDays(1), LocalDateTime.now().minusMinutes(1));
+    Drops active = createDrop(2L, 1L, now.minusDays(1), now.minusMinutes(1));
     active.activate();
 
     given(dropsService.findActiveDropsToFinish(eq(now))).willReturn(List.of(active));


### PR DESCRIPTION
## 📌 PR 제목
test: drops 도메인 테스트 픽스처 정합성 및 낙관적 락 검증 강화

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `DropsFacadeServiceTest`에서 상태와 시간축이 일치하도록 테스트 픽스처를 분리했습니다.
  - `SCHEDULED`: `startAt > now`
  - `ACTIVE`: `startAt <= now < endAt`
  - `FINISHED(재활성화 가능)`: `status=FINISHED && endAt > now`
- ACTIVE/FINISHED 시나리오에서 단순 `status` 강제 변경 방식 대신, 시간 조건까지 포함된 픽스처를 사용하도록 수정했습니다.
- 낙관적 락 테스트(`restoreStockForOrder_optimisticLockIgnore`)에
  `updateStatusByDrop(product, ProductStatus.ON_SALE)` 호출 검증을 추가해
  “재활성화 시도 자체가 발생했는지”를 명확히 고정했습니다.
- 삭제 차단 테스트에서 실제 서비스 의존성과 맞도록 `OrderHistoryQueryService` 목킹 기준을 정리했습니다.
- 테스트 가독성 향상을 위해 공통 상수(`DEFAULT_DROP_ID`, `DEFAULT_PRODUCT_ID`) 및 헬퍼 메서드를 정리했습니다.

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

- close #이슈번호기입

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] 단위 테스트 실행 완료 (`DropsFacadeServiceTest`)
- [x] 낙관적 락 예외 시나리오 확인
- [x] 상태/시간 정합성 기반 시나리오 검증

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

- 이번 PR은 운영 코드 변경 없이 테스트 코드 안정성과 의도 고정에 초점을 맞췄습니다.
- 특히 시간 기반 도메인 로직이 추후 강화되더라도, 기존처럼 “시간상 성립하지 않는 상태 조합”으로 인한 false positive가 발생하지 않도록 보강했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 일관성 개선: 결정화된 타임스탬프 사용으로 재현성 강화
  * 테스트 검증 강화: 명시적 시간 값 기반의 정확한 주장 추가
  * 테스트 유틸리티 정리: 특화된 생성 헬퍼 도입으로 테스트 가독성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->