### PR TITLE
refactor: drops/product 구조 개선 및 컨트롤러 테스트 보강

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
+    implementation 'org.flywaydb:flyway-core'
+    runtimeOnly 'org.flywaydb:flyway-mysql'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     implementation 'software.amazon.awssdk:auth'
     implementation 'software.amazon.awssdk:regions'
     implementation 'software.amazon.awssdk:s3'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
 
 }
 

--- a/src/main/java/com/example/dropshop/DropshopApplication.java
+++ b/src/main/java/com/example/dropshop/DropshopApplication.java
@@ -1,5 +1,6 @@
 package com.example.dropshop;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -8,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 //@EnableJpaAuditing jpaconfig 에포함
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT1M")
 @ConfigurationPropertiesScan
 public class DropshopApplication {
 

--- a/src/main/java/com/example/dropshop/common/config/ShedLockConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/ShedLockConfig.java
@@ -1,0 +1,28 @@
+package com.example.dropshop.common.config;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * ShedLock JDBC LockProvider 설정.
+ */
+@Configuration
+public class ShedLockConfig {
+
+  @Bean
+  public LockProvider lockProvider(DataSource dataSource) {
+    return new JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(new JdbcTemplate(dataSource))
+            .usingDbTime()
+            .withTableName("shedlock")
+            .build()
+    );
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/common/security/SellerAuthResolver.java
+++ b/src/main/java/com/example/dropshop/common/security/SellerAuthResolver.java
@@ -8,9 +8,7 @@ import com.example.dropshop.domain.seller.service.SellerFacadeService;
 import com.example.dropshop.domain.user.entity.User;
 import com.example.dropshop.domain.user.enums.UserRole;
 import com.example.dropshop.domain.user.service.UserFacadeService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,10 +24,9 @@ public class SellerAuthResolver {
   private final SellerFacadeService sellerFacadeService;
 
   /**
-   * JWT 인증 정보를 기반으로 판매자 인증 컨텍스트를 해석한다.
+   * JWT principal(email)을 기반으로 판매자 인증 컨텍스트를 해석한다.
    */
-  public SellerAuthContext resolve(Authentication authentication) {
-    String email = authentication == null ? null : authentication.getName();
+  public SellerAuthContext resolve(String email) {
     if (email == null || email.isBlank() || ANONYMOUS_USER.equals(email)) {
       throw new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED);
     }

--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsController.java
@@ -17,7 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -44,10 +44,10 @@ public class DropsController {
    */
   @PostMapping
   public ResponseEntity<ApiResponse<DropResponse>> createDrop(
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody DropCreateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     DropResponse response = dropsFacadeService.createSellerDrop(
         sellerAuth.sellerId(),
         sellerAuth.sellerApproved(),
@@ -63,10 +63,10 @@ public class DropsController {
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<DropResponse>> updateDrop(
       @PathVariable Long id,
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody DropUpdateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     DropResponse response = dropsFacadeService.updateSellerDrop(
         id,
         sellerAuth.sellerId(),
@@ -83,9 +83,9 @@ public class DropsController {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteDrop(
       @PathVariable Long id,
-      Authentication authentication
+      @AuthenticationPrincipal String email
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     dropsFacadeService.deleteSellerDrop(
         id,
         sellerAuth.sellerId(),
@@ -101,9 +101,9 @@ public class DropsController {
   @PatchMapping("/{id}/stop")
   public ResponseEntity<ApiResponse<DropResponse>> stopDrop(
       @PathVariable Long id,
-      Authentication authentication
+      @AuthenticationPrincipal String email
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     DropResponse response = dropsFacadeService.stopSellerDrop(
         id,
         sellerAuth.sellerId(),
@@ -119,11 +119,11 @@ public class DropsController {
   @GetMapping("/mine")
   public ResponseEntity<
       ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getMyDrops(
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
       Pageable pageable
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     Page<DropListItemResponse> response = dropsQueryService.findSellerDrops(
         sellerAuth.sellerId(),
         pageable

--- a/src/main/java/com/example/dropshop/domain/drops/dto/request/DropCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/request/DropCreateRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
  * 드랍 생성 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class DropCreateRequest {
 
   @NotNull

--- a/src/main/java/com/example/dropshop/domain/drops/dto/request/DropUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/request/DropUpdateRequest.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
  * 드랍 수정 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class DropUpdateRequest {
 
   private LocalDateTime startAt;

--- a/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
@@ -12,17 +12,17 @@ import lombok.Getter;
 @Builder
 public class DropListItemResponse {
 
-  private Long dropId;
-  private Long productId;
-  private String productName;
-  private String thumbnailUrl;
-  private String status;
-  private LocalDateTime startAt;
-  private LocalDateTime endAt;
-  private Long soldCount;
-  private Long remainStock;
-  private Long purchaseLimit;
-  private boolean useQueue;
+  private final Long dropId;
+  private final Long productId;
+  private final String productName;
+  private final String thumbnailUrl;
+  private final String status;
+  private final LocalDateTime startAt;
+  private final LocalDateTime endAt;
+  private final Long soldCount;
+  private final Long remainStock;
+  private final Long purchaseLimit;
+  private final boolean useQueue;
 
   /**
    * 드랍 엔티티를 목록 응답 DTO로 변환한다.

--- a/src/main/java/com/example/dropshop/domain/drops/dto/response/DropResponse.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/response/DropResponse.java
@@ -12,17 +12,17 @@ import lombok.Getter;
 @Builder
 public class DropResponse {
 
-  private Long dropId;
-  private Long productId;
-  private String status;
-  private LocalDateTime startAt;
-  private LocalDateTime endAt;
-  private Long totalStock;
-  private Long remainStock;
-  private Long purchaseLimit;
-  private boolean useQueue;
-  private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
+  private final Long dropId;
+  private final Long productId;
+  private final String status;
+  private final LocalDateTime startAt;
+  private final LocalDateTime endAt;
+  private final Long totalStock;
+  private final Long remainStock;
+  private final Long purchaseLimit;
+  private final boolean useQueue;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime modifiedAt;
 
   /**
    * 드랍 엔티티를 응답 DTO로 변환한다.

--- a/src/main/java/com/example/dropshop/domain/drops/entity/Drops.java
+++ b/src/main/java/com/example/dropshop/domain/drops/entity/Drops.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
     name = "drops",
     indexes = {
         @Index(name = "idx_drops_product_id", columnList = "product_id"),
+        @Index(name = "idx_drops_product_created_at", columnList = "product_id, created_at"),
         @Index(name = "idx_drops_status_start_at", columnList = "status, start_at"),
         @Index(name = "idx_drops_status_end_at", columnList = "status, end_at"),
         @Index(name = "idx_drops_status_remain_stock", columnList = "status, remain_stock")

--- a/src/main/java/com/example/dropshop/domain/drops/scheduler/DropsStatusScheduler.java
+++ b/src/main/java/com/example/dropshop/domain/drops/scheduler/DropsStatusScheduler.java
@@ -3,17 +3,20 @@ package com.example.dropshop.domain.drops.scheduler;
 import com.example.dropshop.domain.drops.service.DropsStatusTransitionService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
  * 드랍 상태 자동 전이 스케줄러.
  */
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DropsStatusScheduler {
+
+  private static final Logger log = LoggerFactory.getLogger(DropsStatusScheduler.class);
 
   private final DropsStatusTransitionService dropsStatusTransitionService;
   private final DropsSchedulerProperties dropsSchedulerProperties;
@@ -22,6 +25,11 @@ public class DropsStatusScheduler {
    * 드랍 상태 자동 전이 작업을 주기적으로 실행한다.
    */
   @Scheduled(fixedDelayString = "${drops.scheduler.fixed-delay-millis:30000}")
+  @SchedulerLock(
+      name = "dropsStatusScheduler_transitionDropsStatus",
+      lockAtMostFor = "${drops.scheduler.lock-at-most-for:PT1M}",
+      lockAtLeastFor = "${drops.scheduler.lock-at-least-for:PT1S}"
+  )
   public void transitionDropsStatus() {
     if (!dropsSchedulerProperties.isEnabled()) {
       log.debug("[DropsStatusScheduler] 스케줄러 비활성화 상태입니다.");

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsConstants.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsConstants.java
@@ -1,0 +1,29 @@
+package com.example.dropshop.domain.drops.service;
+
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * 드랍 도메인에서 공통으로 사용하는 상태 집합 상수.
+ */
+public final class DropsConstants {
+
+  public static final Set<DropsStatus> ONGOING_DROP_STATUSES = Collections.unmodifiableSet(
+      EnumSet.of(
+          DropsStatus.SCHEDULED,
+          DropsStatus.ACTIVE
+      )
+  );
+
+  public static final Set<DropsStatus> NON_DELETABLE_DROP_STATUSES = Collections.unmodifiableSet(
+      EnumSet.allOf(DropsStatus.class)
+  );
+
+  public static final Set<DropsStatus> PUBLIC_VISIBLE_STATUSES = NON_DELETABLE_DROP_STATUSES;
+
+  private DropsConstants() {
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DropsQueryService {
 
   private static final Set<DropsStatus> PUBLIC_VISIBLE_STATUSES =
-      DropsService.PUBLIC_VISIBLE_STATUSES;
+      DropsConstants.PUBLIC_VISIBLE_STATUSES;
 
   private final DropsRepository dropsRepository;
 

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsService.java
@@ -10,12 +10,10 @@ import com.example.dropshop.domain.drops.repository.DropsRepository;
 import com.example.dropshop.domain.product.entity.Product;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,19 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DropsService {
-
-  static final Set<DropsStatus> ONGOING_DROP_STATUSES = EnumSet.of(
-      DropsStatus.SCHEDULED,
-      DropsStatus.ACTIVE
-  );
-
-  static final Set<DropsStatus> NON_DELETABLE_DROP_STATUSES = EnumSet.of(
-      DropsStatus.SCHEDULED,
-      DropsStatus.ACTIVE,
-      DropsStatus.FINISHED
-  );
-
-  static final Set<DropsStatus> PUBLIC_VISIBLE_STATUSES = NON_DELETABLE_DROP_STATUSES;
 
   private final DropsRepository dropsRepository;
 
@@ -126,7 +111,10 @@ public class DropsService {
    */
   @Transactional(readOnly = true)
   public boolean existsOngoingDropForProduct(Long productId) {
-    return dropsRepository.existsByProductIdAndStatusIn(productId, ONGOING_DROP_STATUSES);
+    return dropsRepository.existsByProductIdAndStatusIn(
+        productId,
+        DropsConstants.ONGOING_DROP_STATUSES
+    );
   }
 
   /**
@@ -134,7 +122,10 @@ public class DropsService {
    */
   @Transactional(readOnly = true)
   public boolean existsDropHistoryForProduct(Long productId) {
-    return dropsRepository.existsByProductIdAndStatusIn(productId, NON_DELETABLE_DROP_STATUSES);
+    return dropsRepository.existsByProductIdAndStatusIn(
+        productId,
+        DropsConstants.NON_DELETABLE_DROP_STATUSES
+    );
   }
 
   /**

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionService.java
@@ -1,15 +1,14 @@
 package com.example.dropshop.domain.drops.service;
 
 import com.example.dropshop.domain.drops.entity.Drops;
-import com.example.dropshop.domain.product.enums.ProductStatus;
-import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 드랍 상태 자동 전이 서비스.
@@ -19,28 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DropsStatusTransitionService {
 
+  private static final int MAX_RETRY_ATTEMPTS = 3;
+  private static final long BASE_BACKOFF_MILLIS = 50L;
+  private static final long JITTER_BOUND_MILLIS = 30L;
+
   private final DropsService dropsService;
-  private final ProductDomainFacadeService productDomainFacadeService;
+  private final DropsStatusTransitionWorker transitionWorker;
 
   /**
    * 시작 시간이 된 드랍을 ACTIVE로 전이한다.
    */
-  @Transactional
   public int transitionScheduledToActive(LocalDateTime baseTime) {
     List<Drops> scheduledDrops = dropsService.findScheduledDropsToActivate(baseTime);
     int transitionedCount = 0;
     for (Drops drops : scheduledDrops) {
-      try {
-        if (!drops.isScheduled()) {
-          continue;
-        }
-        drops.activate();
-        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+      if (executeWithRetry(
+          () -> transitionWorker.transitionScheduledDrop(drops.getId()),
+          drops.getId(),
+          "SCHEDULED_TO_ACTIVE"
+      )) {
         transitionedCount++;
-      } catch (OptimisticLockingFailureException e) {
-        log.warn("드랍 ID={} 상태 전이가 동시성 충돌로 스킵되었습니다.", drops.getId(), e);
-      } catch (Exception e) {
-        log.error("드랍 ID={} 상태 전이 중 예기치 않은 오류가 발생했습니다.", drops.getId(), e);
       }
     }
     return transitionedCount;
@@ -49,25 +46,74 @@ public class DropsStatusTransitionService {
   /**
    * 종료 조건을 만족한 드랍을 FINISHED로 전이한다.
    */
-  @Transactional
   public int transitionActiveToFinished(LocalDateTime baseTime) {
     List<Drops> activeDrops = dropsService.findActiveDropsToFinish(baseTime);
     int transitionedCount = 0;
     for (Drops drops : activeDrops) {
-      try {
-        if (!drops.isActive()) {
-          continue;
-        }
-        drops.finish();
-        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+      if (executeWithRetry(
+          () -> transitionWorker.transitionActiveDrop(drops.getId()),
+          drops.getId(),
+          "ACTIVE_TO_FINISHED"
+      )) {
         transitionedCount++;
-      } catch (OptimisticLockingFailureException e) {
-        log.warn("드랍 ID={} 종료 전이가 동시성 충돌로 스킵되었습니다.", drops.getId(), e);
-      } catch (Exception e) {
-        log.error("드랍 ID={} 종료 전이 중 예기치 않은 오류가 발생했습니다.", drops.getId(), e);
       }
     }
     return transitionedCount;
+  }
+
+  private boolean executeWithRetry(
+      Supplier<Boolean> transitionAction,
+      Long dropId,
+      String transitionName
+  ) {
+    for (int attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return transitionAction.get();
+      } catch (OptimisticLockingFailureException e) {
+        if (attempt == MAX_RETRY_ATTEMPTS) {
+          log.warn(
+              "드랍 ID={} {} 전이가 동시성 충돌로 최종 실패했습니다. attempts={}",
+              dropId,
+              transitionName,
+              attempt,
+              e
+          );
+          return false;
+        }
+        if (!waitBeforeRetry(attempt, dropId, transitionName)) {
+          return false;
+        }
+        log.info(
+            "드랍 ID={} {} 전이 동시성 충돌, 재시도합니다. attempt={}/{}",
+            dropId,
+            transitionName,
+            attempt,
+            MAX_RETRY_ATTEMPTS
+        );
+      } catch (Exception e) {
+        log.error("드랍 ID={} {} 전이 중 예기치 않은 오류가 발생했습니다.", dropId, transitionName, e);
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private boolean waitBeforeRetry(int attempt, Long dropId, String transitionName) {
+    long jitter = ThreadLocalRandom.current().nextLong(JITTER_BOUND_MILLIS + 1);
+    long waitMillis = (attempt * BASE_BACKOFF_MILLIS) + jitter;
+    try {
+      Thread.sleep(waitMillis);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn(
+          "드랍 ID={} {} 전이 재시도 대기 중 인터럽트가 발생했습니다.",
+          dropId,
+          transitionName,
+          e
+      );
+      return false;
+    }
   }
 }
 

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
@@ -1,0 +1,59 @@
+package com.example.dropshop.domain.drops.service;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 드랍 상태 전이 단건 처리 워커.
+ */
+@Service
+@RequiredArgsConstructor
+public class DropsStatusTransitionWorker {
+
+  private final DropsService dropsService;
+  private final ProductDomainFacadeService productDomainFacadeService;
+
+  /**
+   * 단일 예정 드랍을 ACTIVE로 전이한다.
+   */
+  @Transactional(
+      propagation = Propagation.REQUIRES_NEW,
+      isolation = Isolation.READ_COMMITTED
+  )
+  public boolean transitionScheduledDrop(Long dropId) {
+    Drops drops = dropsService.findById(dropId);
+    if (!drops.isScheduled()) {
+      return false;
+    }
+
+    drops.activate();
+    productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+    return true;
+  }
+
+  /**
+   * 단일 진행 중 드랍을 FINISHED로 전이한다.
+   */
+  @Transactional(
+      propagation = Propagation.REQUIRES_NEW,
+      isolation = Isolation.READ_COMMITTED
+  )
+  public boolean transitionActiveDrop(Long dropId) {
+    Drops drops = dropsService.findById(dropId);
+    if (!drops.isActive()) {
+      return false;
+    }
+
+    drops.finish();
+    productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+    return true;
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/dropshop/domain/product/controller/ProductController.java
@@ -19,7 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -46,10 +46,10 @@ public class ProductController {
    */
   @PostMapping
   public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody ProductCreateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
 
     ProductCreateResponse response = productFacadeService.createSellerProduct(
         sellerAuth.sellerId(),
@@ -67,10 +67,10 @@ public class ProductController {
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<ProductCreateResponse>> updateProduct(
       @PathVariable Long id,
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody ProductUpdateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     ProductCreateResponse response = productFacadeService.updateSellerProduct(
         id,
         sellerAuth.sellerId(),
@@ -87,10 +87,10 @@ public class ProductController {
   @PatchMapping("/{id}/status")
   public ResponseEntity<ApiResponse<ProductCreateResponse>> updateProductStatus(
       @PathVariable Long id,
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody ProductStatusUpdateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     ProductCreateResponse response = productFacadeService.changeSellerProductStatus(
         id,
         sellerAuth.sellerId(),
@@ -107,9 +107,9 @@ public class ProductController {
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteProduct(
       @PathVariable Long id,
-      Authentication authentication
+      @AuthenticationPrincipal String email
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     productFacadeService.deleteSellerProduct(
         id,
         sellerAuth.sellerId(),
@@ -125,10 +125,10 @@ public class ProductController {
   @PostMapping("/{id}/images")
   public ResponseEntity<ApiResponse<ProductImageResponse>> createProductImage(
       @PathVariable Long id,
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody ProductImageCreateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     ProductImageResponse response = productFacadeService.createSellerProductImage(
         id,
         sellerAuth.sellerId(),
@@ -146,10 +146,10 @@ public class ProductController {
   public ResponseEntity<ApiResponse<ProductImageResponse>> updateProductImage(
       @PathVariable Long id,
       @PathVariable Long imageId,
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody ProductImageUpdateRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     ProductImageResponse response = productFacadeService.updateSellerProductImage(
         id,
         imageId,
@@ -168,9 +168,9 @@ public class ProductController {
   public ResponseEntity<ApiResponse<Void>> deleteProductImage(
       @PathVariable Long id,
       @PathVariable Long imageId,
-      Authentication authentication
+      @AuthenticationPrincipal String email
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     productFacadeService.deleteSellerProductImage(
         id,
         imageId,
@@ -187,11 +187,11 @@ public class ProductController {
   @GetMapping("/mine")
   public ResponseEntity<
       ApiResponse<ApiResponse.PageResponse<SellerProductListItemResponse>>> findMineProducts(
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
     Pageable pageable = PageRequest.of(page, size);
     Page<SellerProductListItemResponse> response = productFacadeService.findSellerProducts(
         sellerAuth.sellerId(),

--- a/src/main/java/com/example/dropshop/domain/product/controller/SellerImageController.java
+++ b/src/main/java/com/example/dropshop/domain/product/controller/SellerImageController.java
@@ -10,7 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,10 +32,10 @@ public class SellerImageController {
    */
   @PostMapping("/presigned-url")
   public ResponseEntity<ApiResponse<PresignedUrlIssueResponse>> issuePresignedUrl(
-      Authentication authentication,
+      @AuthenticationPrincipal String email,
       @Valid @RequestBody PresignedUrlIssueRequest request
   ) {
-    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(authentication);
+    SellerAuthContext sellerAuth = sellerAuthResolver.resolve(email);
 
     PresignedUrlIssueResponse response = productImageUploadService.issuePresignedUrl(
         sellerAuth.sellerId(),

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/PresignedUrlIssueRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/PresignedUrlIssueRequest.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
  * 상품 이미지 Presigned URL 발급 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class PresignedUrlIssueRequest {
 
   @NotBlank

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
@@ -16,7 +16,6 @@ import lombok.NoArgsConstructor;
  * 상품 등록 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class ProductCreateRequest {
 
   @NotBlank
@@ -52,7 +51,6 @@ public class ProductCreateRequest {
    * 상품 이미지 등록 요청 DTO.
    */
   @Getter
-  @NoArgsConstructor
   public static class ImageRequest {
 
     @NotBlank

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageCreateRequest.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
  * 상품 이미지 추가 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class ProductImageCreateRequest {
 
   @NotBlank

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageUpdateRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
  * 상품 이미지 수정 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class ProductImageUpdateRequest {
 
   @Min(1)

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductStatusUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductStatusUpdateRequest.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
  * 상품 상태 변경 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class ProductStatusUpdateRequest {
 
   @NotNull

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductUpdateRequest.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
  * 상품 정보 수정 요청 DTO.
  */
 @Getter
-@NoArgsConstructor
 public class ProductUpdateRequest {
 
   @Size(min = 1, max = 100)

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/PresignedUrlIssueResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/PresignedUrlIssueResponse.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Builder
 public class PresignedUrlIssueResponse {
 
-  private String presignedUrl;
-  private String imageUrl;
+  private final String presignedUrl;
+  private final String imageUrl;
 }
 

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/ProductCreateResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/ProductCreateResponse.java
@@ -13,17 +13,17 @@ import lombok.Getter;
 @Builder
 public class ProductCreateResponse {
 
-  private Long productId;
-  private String name;
-  private BigDecimal price;
-  private int discountRate;
-  private BigDecimal discountAmount;
-  private BigDecimal salePrice;
-  private int stock;
-  private String category;
-  private String status;
-  private String thumbnailUrl;
-  private LocalDateTime createdAt;
+  private final Long productId;
+  private final String name;
+  private final BigDecimal price;
+  private final int discountRate;
+  private final BigDecimal discountAmount;
+  private final BigDecimal salePrice;
+  private final int stock;
+  private final String category;
+  private final String status;
+  private final String thumbnailUrl;
+  private final LocalDateTime createdAt;
 
   /**
    * Product 엔티티를 등록 응답 DTO로 변환한다.

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/ProductDetailResponse.java
@@ -17,26 +17,26 @@ import lombok.Getter;
 @Builder
 public class ProductDetailResponse {
 
-  private Long productId;
-  private String name;
-  private BigDecimal price;
-  private int discountRate;
-  private BigDecimal discountAmount;
-  private BigDecimal salePrice;
-  private int stock;
-  private String category;
-  private String status;
-  private String thumbnailUrl;
-  private String description;
-  private String specification;
-  private String deliveryInfo;
-  private String refundPolicy;
-  private boolean isPurchasable;
-  private SellerInfo seller;
-  private DropInfo latestDrop;
-  private List<ProductImageResponse> images;
-  private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
+  private final Long productId;
+  private final String name;
+  private final BigDecimal price;
+  private final int discountRate;
+  private final BigDecimal discountAmount;
+  private final BigDecimal salePrice;
+  private final int stock;
+  private final String category;
+  private final String status;
+  private final String thumbnailUrl;
+  private final String description;
+  private final String specification;
+  private final String deliveryInfo;
+  private final String refundPolicy;
+  private final boolean isPurchasable;
+  private final SellerInfo seller;
+  private final DropInfo latestDrop;
+  private final List<ProductImageResponse> images;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime modifiedAt;
 
   /**
    * 상세 응답 객체를 생성한다.
@@ -80,9 +80,9 @@ public class ProductDetailResponse {
   @Builder
   public static class SellerInfo {
 
-    private Long sellerId;
-    private String email;
-    private String nickname;
+    private final Long sellerId;
+    private final String email;
+    private final String nickname;
 
     /**
      * 사용자 엔티티로 판매자 정보를 생성한다.
@@ -110,14 +110,14 @@ public class ProductDetailResponse {
   @Builder
   public static class DropInfo {
 
-    private Long dropId;
-    private String status;
-    private LocalDateTime startAt;
-    private LocalDateTime endAt;
-    private Long totalStock;
-    private Long remainStock;
-    private Long purchaseLimit;
-    private boolean useQueue;
+    private final Long dropId;
+    private final String status;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+    private final Long totalStock;
+    private final Long remainStock;
+    private final Long purchaseLimit;
+    private final boolean useQueue;
 
     /**
      * 드랍 엔티티로 최신 드랍 정보를 생성한다.
@@ -146,10 +146,10 @@ public class ProductDetailResponse {
   @Builder
   public static class ProductImageResponse {
 
-    private Long imageId;
-    private String imageUrl;
-    private int sortOrder;
-    private boolean isThumbnail;
+    private final Long imageId;
+    private final String imageUrl;
+    private final int sortOrder;
+    private final boolean isThumbnail;
 
     /**
      * 상품 이미지 엔티티로 상세 이미지 정보를 생성한다.

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/ProductImageResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/ProductImageResponse.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 @Builder
 public class ProductImageResponse {
 
-  private Long imageId;
-  private Long productId;
-  private String imageUrl;
-  private int sortOrder;
-  private boolean isThumbnail;
+  private final Long imageId;
+  private final Long productId;
+  private final String imageUrl;
+  private final int sortOrder;
+  private final boolean isThumbnail;
 
   /**
    * ProductImage 엔티티를 이미지 응답 DTO로 변환한다.

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/ProductListItemResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/ProductListItemResponse.java
@@ -14,13 +14,13 @@ import lombok.Getter;
 @Builder
 public class ProductListItemResponse {
 
-  private Long productId;
-  private String name;
-  private BigDecimal salePrice;
-  private int discountRate;
-  private String thumbnailUrl;
-  private String status;
-  private LocalDateTime dropStartAt;
+  private final Long productId;
+  private final String name;
+  private final BigDecimal salePrice;
+  private final int discountRate;
+  private final String thumbnailUrl;
+  private final String status;
+  private final LocalDateTime dropStartAt;
 
   /**
    * Product와 최신 Drop으로 목록 아이템을 생성한다.

--- a/src/main/java/com/example/dropshop/domain/product/dto/response/SellerProductListItemResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/response/SellerProductListItemResponse.java
@@ -13,13 +13,13 @@ import lombok.Getter;
 @Builder
 public class SellerProductListItemResponse {
 
-  private Long productId;
-  private String name;
-  private String status;
-  private BigDecimal salePrice;
-  private int stock;
-  private String thumbnailUrl;
-  private LocalDateTime createdAt;
+  private final Long productId;
+  private final String name;
+  private final String status;
+  private final BigDecimal salePrice;
+  private final int stock;
+  private final String thumbnailUrl;
+  private final LocalDateTime createdAt;
 
   /**
    * Product를 판매자 목록 아이템으로 변환한다.

--- a/src/main/java/com/example/dropshop/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/dropshop/domain/product/repository/ProductRepository.java
@@ -2,7 +2,6 @@ package com.example.dropshop.domain.product.repository;
 
 import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductStatus;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 /**
  * 상품 엔티티 저장소.
  */
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
   /**
    * 공개 상품 목록을 상태 기준으로 조회한다.
@@ -34,25 +33,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
   @Query("select p from Product p where p.id = :id")
   Optional<Product> findDetailById(@Param("id") Long id);
 
-  /**
-   * 드랍 시작 임박 순으로 공개 상품을 조회한다.
-   */
-  @Query(
-      "select p from Product p "
-          + "where p.status in :statuses "
-          + "order by "
-          + "case when ("
-          + "select min(d.startAt) from Drops d "
-          + "where d.product.id = p.id and d.startAt >= :baseTime"
-          + ") is null then 1 else 0 end, "
-          + "(select min(d.startAt) from Drops d "
-          + "where d.product.id = p.id and d.startAt >= :baseTime) asc, "
-          + "p.createdAt desc"
-  )
-  Page<Product> findPublicProductsOrderByDropImminent(
-      @Param("statuses") Collection<ProductStatus> statuses,
-      @Param("baseTime") LocalDateTime baseTime,
-      Pageable pageable
-  );
 }
 

--- a/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,27 @@
+package com.example.dropshop.domain.product.repository;
+
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.enums.ProductListSortType;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 상품 조회용 커스텀 리포지토리.
+ */
+public interface ProductRepositoryCustom {
+
+  /**
+   * 공개 상품 목록을 동적 정렬 조건으로 조회한다.
+   * pageable의 sort는 사용하지 않고 sortType 기준 정렬만 적용한다.
+   */
+  Page<Product> findPublicProducts(
+      Collection<ProductStatus> statuses,
+      ProductListSortType sortType,
+      LocalDateTime baseTime,
+      Pageable pageable
+  );
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -1,0 +1,110 @@
+package com.example.dropshop.domain.product.repository;
+
+import static com.example.dropshop.domain.drops.entity.QDrops.drops;
+import static com.example.dropshop.domain.product.entity.QProduct.product;
+
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.enums.ProductListSortType;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+/**
+ * 상품 조회용 Querydsl 커스텀 구현체.
+ */
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<Product> findPublicProducts(
+      Collection<ProductStatus> statuses,
+      ProductListSortType sortType,
+      LocalDateTime baseTime,
+      Pageable pageable
+  ) {
+    BooleanExpression predicate = product.status.in(statuses);
+
+    List<Product> content = queryFactory
+        .selectFrom(product)
+        .where(predicate)
+        .orderBy(resolveOrderSpecifiers(sortType, baseTime))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    return PageableExecutionUtils.getPage(
+        content,
+        pageable,
+        () -> {
+          Long total = queryFactory
+              .select(product.count())
+              .from(product)
+              .where(predicate)
+              .fetchOne();
+          return total == null ? 0L : total;
+        }
+    );
+  }
+
+  private OrderSpecifier<?>[] resolveOrderSpecifiers(
+      ProductListSortType sortType,
+      LocalDateTime baseTime
+  ) {
+    return switch (sortType) {
+      case PRICE_HIGH -> new OrderSpecifier<?>[] {
+          product.salePrice.desc(),
+          product.createdAt.desc()
+      };
+      case PRICE_LOW -> new OrderSpecifier<?>[] {
+          product.salePrice.asc(),
+          product.createdAt.desc()
+      };
+      case DROP_IMMINENT -> resolveDropImminentOrderSpecifiers(baseTime);
+      case LATEST -> new OrderSpecifier<?>[] {
+          product.createdAt.desc()
+      };
+    };
+  }
+
+  private OrderSpecifier<?>[] resolveDropImminentOrderSpecifiers(LocalDateTime baseTime) {
+    Expression<LocalDateTime> nextDropStartAt = nextDropStartAt(baseTime);
+    NumberExpression<Integer> nullRank = Expressions.numberTemplate(
+        Integer.class,
+        "case when ({0}) is null then 1 else 0 end",
+        nextDropStartAt
+    );
+
+    return new OrderSpecifier<?>[] {
+        nullRank.asc(),
+        new OrderSpecifier<>(Order.ASC, nextDropStartAt),
+        product.createdAt.desc()
+    };
+  }
+
+  private Expression<LocalDateTime> nextDropStartAt(LocalDateTime baseTime) {
+    return JPAExpressions
+        .select(drops.startAt.min())
+        .from(drops)
+        .where(
+            drops.product.id.eq(product.id),
+            drops.startAt.goe(baseTime)
+        );
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
@@ -10,8 +10,8 @@ import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductListSortType;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.exception.ProductException;
-import com.example.dropshop.domain.product.repository.ProductRepository;
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.product.repository.ProductRepository;
 import com.example.dropshop.domain.user.entity.User;
 import com.example.dropshop.domain.user.service.UserFacadeService;
 import java.time.Duration;
@@ -110,25 +110,16 @@ public class ProductQueryService {
       ProductListSortType sortType,
       Pageable pageable
   ) {
-    return switch (sortType) {
-      case PRICE_HIGH -> productRepository.findAllByStatusIn(
-          statuses,
-          applySort(pageable, Sort.by(Sort.Direction.DESC, "salePrice"))
-      );
-      case PRICE_LOW -> productRepository.findAllByStatusIn(
-          statuses,
-          applySort(pageable, Sort.by(Sort.Direction.ASC, "salePrice"))
-      );
-      case DROP_IMMINENT -> productRepository.findPublicProductsOrderByDropImminent(
-          statuses,
-          LocalDateTime.now(),
-          pageable
-      );
-      case LATEST -> productRepository.findAllByStatusIn(
-          statuses,
-          applySort(pageable, Sort.by(Sort.Direction.DESC, "createdAt"))
-      );
-    };
+    Pageable normalizedPageable = PageRequest.of(
+        pageable.getPageNumber(),
+        pageable.getPageSize()
+    );
+    return productRepository.findPublicProducts(
+        statuses,
+        sortType,
+        LocalDateTime.now(),
+        normalizedPageable
+    );
   }
 
   private Collection<ProductStatus> parsePublicStatusFilter(String status) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,8 @@ drops:
   scheduler:
     enabled: true
     fixed-delay-millis: 30000
+    lock-at-most-for: PT1M
+    lock-at-least-for: PT1S
 
 jwt:
   access-token-expiration: 3600000 # 1시간 (ms 단위)

--- a/src/main/resources/db/migration/V1__create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V1__create_shedlock_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS shedlock (
+  name VARCHAR(64) NOT NULL,
+  lock_until TIMESTAMP(3) NOT NULL,
+  locked_at TIMESTAMP(3) NOT NULL,
+  locked_by VARCHAR(255) NOT NULL,
+  PRIMARY KEY (name)
+) ENGINE=InnoDB;
+

--- a/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
@@ -1,0 +1,197 @@
+package com.example.dropshop.domain.drops.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.exception.ServiceException;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
+import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
+import com.example.dropshop.domain.drops.service.DropsFacadeService;
+import com.example.dropshop.domain.drops.service.DropsQueryService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DropsController.class)
+class DropsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private DropsFacadeService dropsFacadeService;
+
+  @MockitoBean
+  // /mine 조회 케이스를 같은 클래스에서 확장할 때 재사용한다.
+  private DropsQueryService dropsQueryService;
+
+  @MockitoBean
+  private SellerAuthResolver sellerAuthResolver;
+
+  @Test
+  @DisplayName("드랍 생성 성공 - @AuthenticationPrincipal email 사용")
+  void createDrop_success() throws Exception {
+    LocalDateTime startAt = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+    LocalDateTime endAt = LocalDateTime.of(2026, 5, 1, 11, 0, 0);
+
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    DropResponse response = DropResponse.builder()
+        .dropId(10L)
+        .productId(100L)
+        .status("SCHEDULED")
+        .startAt(startAt)
+        .endAt(endAt)
+        .totalStock(50L)
+        .remainStock(50L)
+        .purchaseLimit(1L)
+        .useQueue(true)
+        .createdAt(LocalDateTime.of(2026, 4, 23, 10, 0, 0))
+        .modifiedAt(LocalDateTime.of(2026, 4, 23, 10, 0, 0))
+        .build();
+
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(dropsFacadeService.createSellerDrop(
+        eq(1L),
+        eq(true),
+        eq(true),
+        any(DropCreateRequest.class)
+    )).willReturn(response);
+
+    String request = """
+        {
+          "productId": 100,
+          "startAt": "2026-05-01T10:00:00",
+          "endAt": "2026-05-01T11:00:00",
+          "totalStock": 50,
+          "purchaseLimit": 1,
+          "useQueue": true
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.code").value(201))
+        .andExpect(jsonPath("$.data.dropId").value(10L))
+        .andExpect(jsonPath("$.data.productId").value(100L))
+        .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+        .andExpect(jsonPath("$.data.startAt").value("2026-05-01T10:00:00"))
+        .andExpect(jsonPath("$.data.endAt").value("2026-05-01T11:00:00"))
+        .andExpect(jsonPath("$.data.totalStock").value(50))
+        .andExpect(jsonPath("$.data.remainStock").value(50))
+        .andExpect(jsonPath("$.data.purchaseLimit").value(1))
+        .andExpect(jsonPath("$.data.useQueue").value(true));
+  }
+
+  @Test
+  @DisplayName("드랍 생성 실패 - 유효성 검증 실패 시 400")
+  void createDrop_validationFail() throws Exception {
+    String invalidRequest = """
+        {
+          "productId": null,
+          "startAt": "2026-05-01T10:00:00",
+          "endAt": "2026-05-01T11:00:00",
+          "totalStock": 50,
+          "purchaseLimit": 1,
+          "useQueue": true
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(invalidRequest))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.data.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.data.message").exists());
+  }
+
+  @Test
+  @DisplayName("드랍 생성 실패 - 미인증 요청")
+  void createDrop_unauthorized() throws Exception {
+    // 인증 컨텍스트를 해석하지 못한 경우(미인증/권한 없음)를 resolver에서 표현한다.
+    given(sellerAuthResolver.resolve(any()))
+        .willThrow(new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED));
+
+    String request = """
+        {
+          "productId": 100,
+          "startAt": "2026-05-01T10:00:00",
+          "endAt": "2026-05-01T11:00:00",
+          "totalStock": 50,
+          "purchaseLimit": 1,
+          "useQueue": true
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value(403));
+
+    verifyNoInteractions(dropsFacadeService);
+  }
+
+  @Test
+  @DisplayName("드랍 생성 실패 - 서비스 예외 응답 구조")
+  void createDrop_serviceException() throws Exception {
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(dropsFacadeService.createSellerDrop(
+        eq(1L),
+        eq(true),
+        eq(true),
+        any(DropCreateRequest.class)
+    )).willThrow(new ServiceException(ErrorCode.DROP_ALREADY_EXISTS));
+
+    String request = """
+        {
+          "productId": 100,
+          "startAt": "2026-05-01T10:00:00",
+          "endAt": "2026-05-01T11:00:00",
+          "totalStock": 50,
+          "purchaseLimit": 1,
+          "useQueue": true
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/drops")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value(400))
+        .andExpect(jsonPath("$.message").value(ErrorCode.DROP_ALREADY_EXISTS.getMessage()));
+
+    verify(dropsFacadeService).createSellerDrop(eq(1L), eq(true), eq(true), any(DropCreateRequest.class));
+  }
+}
+
+
+

--- a/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/DropsControllerTest.java
@@ -186,7 +186,7 @@ class DropsControllerTest {
             .contentType(APPLICATION_JSON)
             .content(request))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.errorCode").value(400))
+        .andExpect(jsonPath("$.errorCode").value("DROP_ALREADY_EXISTS"))
         .andExpect(jsonPath("$.message").value(ErrorCode.DROP_ALREADY_EXISTS.getMessage()));
 
     verify(dropsFacadeService).createSellerDrop(eq(1L), eq(true), eq(true), any(DropCreateRequest.class));

--- a/src/test/java/com/example/dropshop/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/product/controller/ProductControllerTest.java
@@ -1,0 +1,204 @@
+package com.example.dropshop.domain.product.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.exception.ServiceException;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
+import com.example.dropshop.domain.product.dto.request.ProductCreateRequest;
+import com.example.dropshop.domain.product.dto.response.ProductCreateResponse;
+import com.example.dropshop.domain.product.service.ProductFacadeService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private ProductFacadeService productFacadeService;
+
+  @MockitoBean
+  private SellerAuthResolver sellerAuthResolver;
+
+  @Test
+  @DisplayName("상품 등록 성공 - @AuthenticationPrincipal email 사용")
+  void createProduct_success() throws Exception {
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    ProductCreateResponse response = ProductCreateResponse.builder()
+        .productId(42L)
+        .name("한정판 스니커즈")
+        .price(BigDecimal.valueOf(250000))
+        .discountRate(10)
+        .discountAmount(BigDecimal.valueOf(25000))
+        .salePrice(BigDecimal.valueOf(225000))
+        .stock(100)
+        .category("SHOES")
+        .status("HIDDEN")
+        .thumbnailUrl("https://cdn.example.com/img1.jpg")
+        .createdAt(LocalDateTime.of(2026, 4, 10, 10, 0, 0))
+        .build();
+
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(productFacadeService.createSellerProduct(
+        eq(1L),
+        eq(true),
+        eq(true),
+        any(ProductCreateRequest.class)
+    )).willReturn(response);
+
+    String request = """
+        {
+          "name": "한정판 스니커즈",
+          "price": 250000,
+          "discountRate": 10,
+          "stock": 100,
+          "category": "SHOES",
+          "description": "<p>상품 설명 HTML</p>",
+          "specification": "사이즈: 255 / 소재: 가죽",
+          "images": [
+            {
+              "imageUrl": "https://cdn.example.com/img1.jpg",
+              "sortOrder": 1,
+              "isThumbnail": true
+            }
+          ]
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/products")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.code").value(201))
+        .andExpect(jsonPath("$.data.productId").value(42L))
+        .andExpect(jsonPath("$.data.name").value("한정판 스니커즈"))
+        .andExpect(jsonPath("$.data.price").value(250000))
+        .andExpect(jsonPath("$.data.discountRate").value(10))
+        .andExpect(jsonPath("$.data.salePrice").value(225000))
+        .andExpect(jsonPath("$.data.stock").value(100))
+        .andExpect(jsonPath("$.data.category").value("SHOES"))
+        .andExpect(jsonPath("$.data.status").value("HIDDEN"))
+        .andExpect(jsonPath("$.data.thumbnailUrl").value("https://cdn.example.com/img1.jpg"));
+  }
+
+  @Test
+  @DisplayName("상품 등록 실패 - 유효성 검증 실패 시 400")
+  void createProduct_validationFail() throws Exception {
+    String invalidRequest = """
+        {
+          "name": "",
+          "price": 250000,
+          "discountRate": 10,
+          "stock": 100,
+          "category": "SHOES",
+          "description": "desc",
+          "specification": "spec",
+          "images": []
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/products")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(invalidRequest))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.data.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.data.message").exists());
+  }
+
+  @Test
+  @DisplayName("상품 등록 실패 - 미인증 요청")
+  void createProduct_unauthorized() throws Exception {
+    // 인증 컨텍스트를 해석하지 못한 경우(미인증/권한 없음)를 resolver에서 표현한다.
+    given(sellerAuthResolver.resolve(any()))
+        .willThrow(new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED));
+
+    String request = """
+        {
+          "name": "한정판 스니커즈",
+          "price": 250000,
+          "discountRate": 10,
+          "stock": 100,
+          "category": "SHOES",
+          "description": "desc",
+          "specification": "spec",
+          "images": [{"imageUrl":"https://cdn.example.com/img1.jpg","sortOrder":1,"isThumbnail":true}]
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/products")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value(403));
+
+    verifyNoInteractions(productFacadeService);
+  }
+
+  @Test
+  @DisplayName("상품 등록 실패 - 서비스 예외 응답 구조")
+  void createProduct_serviceException() throws Exception {
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(productFacadeService.createSellerProduct(
+        eq(1L),
+        eq(true),
+        eq(true),
+        any(ProductCreateRequest.class)
+    )).willThrow(new ServiceException(ErrorCode.SELLER_NOT_APPROVED));
+
+    String request = """
+        {
+          "name": "한정판 스니커즈",
+          "price": 250000,
+          "discountRate": 10,
+          "stock": 100,
+          "category": "SHOES",
+          "description": "desc",
+          "specification": "spec",
+          "images": [{"imageUrl":"https://cdn.example.com/img1.jpg","sortOrder":1,"isThumbnail":true}]
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/products")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value(403))
+        .andExpect(jsonPath("$.message").value(ErrorCode.SELLER_NOT_APPROVED.getMessage()));
+
+    verify(productFacadeService).createSellerProduct(eq(1L), eq(true), eq(true), any());
+  }
+}
+
+
+

--- a/src/test/java/com/example/dropshop/domain/product/controller/SellerImageControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/product/controller/SellerImageControllerTest.java
@@ -1,0 +1,138 @@
+package com.example.dropshop.domain.product.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.exception.ServiceException;
+import com.example.dropshop.common.security.SellerAuthContext;
+import com.example.dropshop.common.security.SellerAuthResolver;
+import com.example.dropshop.domain.product.dto.request.PresignedUrlIssueRequest;
+import com.example.dropshop.domain.product.dto.response.PresignedUrlIssueResponse;
+import com.example.dropshop.domain.product.service.ProductImageUploadService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SellerImageController.class)
+class SellerImageControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+  @MockitoBean
+  private ProductImageUploadService productImageUploadService;
+
+  @MockitoBean
+  private SellerAuthResolver sellerAuthResolver;
+
+  @Test
+  @DisplayName("Presigned URL 발급 성공 - @AuthenticationPrincipal email 사용")
+  void issuePresignedUrl_success() throws Exception {
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    PresignedUrlIssueResponse response = PresignedUrlIssueResponse.builder()
+        .presignedUrl("https://s3.example.com/presigned")
+        .imageUrl("https://cdn.example.com/image.png")
+        .build();
+
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(productImageUploadService.issuePresignedUrl(eq(1L), any(PresignedUrlIssueRequest.class)))
+        .willReturn(response);
+
+    String request = """
+        {
+          "fileType": "png"
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/images/presigned-url")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.code").value(201))
+        .andExpect(jsonPath("$.data.presignedUrl").value("https://s3.example.com/presigned"))
+        .andExpect(jsonPath("$.data.imageUrl").value("https://cdn.example.com/image.png"));
+  }
+
+  @Test
+  @DisplayName("Presigned URL 발급 실패 - 유효성 검증 실패 시 400")
+  void issuePresignedUrl_validationFail() throws Exception {
+    mockMvc.perform(post("/api/sellers/images/presigned-url")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.data.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.data.message").exists());
+  }
+
+  @Test
+  @DisplayName("Presigned URL 발급 실패 - 미인증 요청")
+  void issuePresignedUrl_unauthorized() throws Exception {
+    // 인증 컨텍스트를 해석하지 못한 경우(미인증/권한 없음)를 resolver에서 표현한다.
+    given(sellerAuthResolver.resolve(any()))
+        .willThrow(new ServiceException(ErrorCode.SELLER_ROLE_REQUIRED));
+
+    String request = """
+        {
+          "fileType": "png"
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/images/presigned-url")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value(403));
+
+    verifyNoInteractions(productImageUploadService);
+  }
+
+  @Test
+  @DisplayName("Presigned URL 발급 실패 - 서비스 예외 응답 구조")
+  void issuePresignedUrl_serviceException() throws Exception {
+    SellerAuthContext sellerAuth = new SellerAuthContext(1L, true, true);
+    given(sellerAuthResolver.resolve(any())).willReturn(sellerAuth);
+    given(productImageUploadService.issuePresignedUrl(eq(1L), any(PresignedUrlIssueRequest.class)))
+        .willThrow(new ServiceException(ErrorCode.PRESIGNED_URL_GENERATION_FAILED));
+
+    String request = """
+        {
+          "fileType": "png"
+        }
+        """;
+
+    mockMvc.perform(post("/api/sellers/images/presigned-url")
+            .with(csrf())
+            .contentType(APPLICATION_JSON)
+            .content(request))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.errorCode").value(500))
+        .andExpect(jsonPath("$.message").value(ErrorCode.PRESIGNED_URL_GENERATION_FAILED.getMessage()));
+
+    verify(productImageUploadService).issuePresignedUrl(eq(1L), any(PresignedUrlIssueRequest.class));
+  }
+}
+
+
+


### PR DESCRIPTION
## 📌 PR 제목
refactor: drops/product 구조 개선 및 컨트롤러 테스트 보강

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `drops/product` 요청 DTO의 불필요한 `@NoArgsConstructor` 제거
- `drops/product` 응답 DTO 필드를 `final`로 통일하여 불변성 강화
- `Drops` 엔티티 인덱스 추가로 조회 성능 개선
- `DropsConstants` 분리로 상태 상수 중복 제거 및 관리 일원화
- 스케줄러 중복 실행 방지를 위해 ShedLock 적용
- 드랍 상태 전이 낙관적 락 재시도 로직 추가 (`DropsStatusTransitionWorker` 도입)
- Product 조회 동적 쿼리 적용 (`ProductRepositoryCustom`, `ProductRepositoryCustomImpl`)
- 판매자 인증 흐름을 `@AuthenticationPrincipal` 기반으로 정리
- 컨트롤러 테스트 3종 추가 및 보강
  - `ProductControllerTest`
  - `SellerImageControllerTest`
  - `DropsControllerTest`
- 테스트 케이스 확장
  - 성공 / 유효성 실패 / 미인증 / 서비스 예외
- 예외 응답 구조 정합성 반영
  - Validation 예외: `ApiResponse<ErrorResponse>`
  - ServiceException: `ExceptionResponse`

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #12
- close #15

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [ ] Postman 테스트 완료
- [x] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

- `dev..HEAD` 기준 전체 커밋(리팩토링 + 테스트 보강) 내용을 포함합니다.
- 컨트롤러 테스트는 `@WebMvcTest` 기준으로 작성되었습니다.
- 실행한 테스트 명령어:
```bash
cd "C:\Users\wowls\Desktop\Project\dropshop"
./gradlew.bat test --tests "*ProductControllerTest" --tests "*SellerImageControllerTest" --tests "*DropsControllerTest"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 분산 잠금 및 마이그레이션 지원 추가(Flyway 및 분산 스케줄 잠금)

* **성능 개선**
  * 공개 상품 조회 통합 및 동적 정렬 향상
  * 조회용 DB 인덱스 추가

* **안정성 개선**
  * 상태 전환 재시도 로직 도입으로 동시성 충돌 완화
  * 스케줄러의 다중 인스턴스 중복 실행 방지

* **리팩터**
  * 인증 주체 전달 방식 단순화

* **테스트**
  * 컨트롤러 단위 테스트 대폭 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->