### PR TITLE
refactor: Product/Drops 파사드 누락 메서드 복구 및 컴파일/스타일 정리

### DIFF
--- a/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
   DROP_STOP_NOT_ALLOWED(HttpStatus.BAD_REQUEST,
       "이미 종료된 드랍은 강제 종료할 수 없습니다."),
   INVALID_DROP_START_AT(HttpStatus.BAD_REQUEST, "INVALID_DROP_START_AT"),
+  INVALID_DROP_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "주문 수량은 1 이상이어야 합니다."),
 
   /**
    * Order (세미 콜론 부분 변경 금지).

--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
@@ -13,8 +13,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -62,7 +62,3 @@ public class DropsQueryController {
   }
 
 }
-
-
-
-

--- a/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/ProductDropsQueryController.java
@@ -31,13 +31,12 @@ public class ProductDropsQueryController {
    * 특정 상품의 드롭 이력을 조회한다.
    */
   @GetMapping("/{productId}/drops")
-  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>> getDropsByProduct(
-      @PathVariable Long productId,
-      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-      Pageable pageable
-  ) {
+  public ResponseEntity<ApiResponse<ApiResponse.PageResponse<DropListItemResponse>>>
+      getDropsByProduct(
+          @PathVariable Long productId,
+          @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
     Page<DropListItemResponse> response = dropsQueryService.findDropsByProduct(productId, pageable);
     return ResponseEntity.ok(ApiResponse.ok(response));
   }
 }
-

--- a/src/main/java/com/example/dropshop/domain/drops/dto/request/DropCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/request/DropCreateRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 드랍 생성 요청 DTO.
@@ -32,4 +31,3 @@ public class DropCreateRequest {
   @NotNull
   private Boolean useQueue;
 }
-

--- a/src/main/java/com/example/dropshop/domain/drops/dto/request/DropUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/request/DropUpdateRequest.java
@@ -3,7 +3,6 @@ package com.example.dropshop.domain.drops.dto.request;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 드랍 수정 요청 DTO.
@@ -23,4 +22,3 @@ public class DropUpdateRequest {
 
   private Boolean useQueue;
 }
-

--- a/src/main/java/com/example/dropshop/domain/drops/event/DropsStockRestoreEventListener.java
+++ b/src/main/java/com/example/dropshop/domain/drops/event/DropsStockRestoreEventListener.java
@@ -15,6 +15,12 @@ public class DropsStockRestoreEventListener {
 
   private final DropsFacadeService dropsFacadeService;
 
+  /**
+   * 재고 복구 이벤트를 수신해 드랍 잔여 재고를 복원한다.
+   *
+   * @param event 주문 도메인에서 발행된 재고 복구 이벤트
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
   @EventListener
   public void handle(StockRestoreEvent event) {
     dropsFacadeService.restoreStockForOrder(event.getDropId(), event.getQuantity());

--- a/src/main/java/com/example/dropshop/domain/drops/exception/DropsException.java
+++ b/src/main/java/com/example/dropshop/domain/drops/exception/DropsException.java
@@ -21,6 +21,13 @@ public class DropsException extends ServiceException {
     super(errorCode);
     this.errorCode = errorCode;
   }
+
+  /**
+   * 에러 코드와 사용자 메시지로 드랍 예외를 생성한다.
+   *
+   * @param errorCode 공통 에러 코드
+   * @param message 상세 메시지
+   */
   public DropsException(ErrorCode errorCode, String message) {
     super(errorCode, message);
     this.errorCode = errorCode;

--- a/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
+++ b/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
@@ -2,7 +2,9 @@ package com.example.dropshop.domain.drops.repository;
 
 import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.enums.DropsStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +13,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 /**
  * 드랍 엔티티 저장소.
  */

--- a/src/main/java/com/example/dropshop/domain/drops/scheduler/DropsSchedulerProperties.java
+++ b/src/main/java/com/example/dropshop/domain/drops/scheduler/DropsSchedulerProperties.java
@@ -17,6 +17,13 @@ public class DropsSchedulerProperties {
   private final boolean enabled;
   private final long fixedDelayMillis;
 
+  /**
+   * 드랍 스케줄러 설정값을 생성한다.
+   *
+   * @param enabled 스케줄러 활성화 여부
+   * @param fixedDelayMillis 스케줄러 실행 주기(ms)
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
   public DropsSchedulerProperties(
       @DefaultValue("true") boolean enabled,
       @DefaultValue("30000") @Positive long fixedDelayMillis
@@ -25,5 +32,3 @@ public class DropsSchedulerProperties {
     this.fixedDelayMillis = fixedDelayMillis;
   }
 }
-
-

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
@@ -5,30 +5,23 @@ import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
 import com.example.dropshop.domain.drops.dto.request.DropUpdateRequest;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.entity.Drops;
-import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.exception.DropsException;
+import com.example.dropshop.domain.drops.repository.DropsRepository;
 import com.example.dropshop.domain.order.facade.OrderFacadeService;
-import com.example.dropshop.domain.order.service.OrderHistoryQueryService;
 import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
-import com.example.dropshop.domain.drops.entity.Drops;
-import com.example.dropshop.domain.drops.repository.DropsRepository;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
 
 /**
  * 드랍 도메인 파사드 서비스.
@@ -42,7 +35,6 @@ public class DropsFacadeService {
   private final ProductDomainFacadeService productDomainFacadeService;
   private final OrderFacadeService orderFacadeService;
   private final DropsRepository dropsRepository;
-  private final OrderHistoryQueryService orderHistoryQueryService;
 
   /**
    * 판매자 드랍을 생성한다.
@@ -107,7 +99,7 @@ public class DropsFacadeService {
 
     dropsService.delete(drops);
 
-     if (!dropsService.existsOngoingDropForProduct(product.getId())) {
+    if (!dropsService.existsOngoingDropForProduct(product.getId())) {
       productDomainFacadeService.updateStatusByDrop(product, ProductStatus.HIDDEN);
     }
   }
@@ -146,7 +138,7 @@ public class DropsFacadeService {
   }
 
   private void validateDuplicatedOngoingDrop(Long productId) {
-     if (dropsService.existsOngoingDropForProduct(productId)) {
+    if (dropsService.existsOngoingDropForProduct(productId)) {
       throw new DropsException(ErrorCode.DROP_ALREADY_EXISTS);
     }
   }
@@ -164,7 +156,8 @@ public class DropsFacadeService {
    */
   @Transactional(readOnly = true)
   public Map<Long, Drops> findLatestDropsByProductIds(Collection<Long> productIds) {
-    List<Drops> dropsList = dropsRepository.findAllByProductIdInOrderByProductIdAscStartAtDesc(productIds);
+    List<Drops> dropsList =
+        dropsRepository.findAllByProductIdInOrderByProductIdAscStartAtDesc(productIds);
     Map<Long, Drops> latestDrops = new HashMap<>();
     for (Drops drops : dropsList) {
       Long productId = drops.getProduct().getId();
@@ -192,14 +185,4 @@ public class DropsFacadeService {
       log.info("드랍 ID={} 재활성화가 동시성 충돌로 스킵되었습니다.", dropId, e);
     }
   }
-
-  private void validateOrderableDrop(Drops drops, Long productId) {
-    if (!drops.isActive()) {
-      throw new DropsException(ErrorCode.DROP_ORDER_NOT_ALLOWED);
-    }
-    if (!drops.getProduct().getId().equals(productId)) {
-      throw new DropsException(ErrorCode.DROP_PRODUCT_MISMATCH);
-    }
-  }
 }
-

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
@@ -196,6 +196,10 @@ public class DropsFacadeService {
    */
   @Transactional
   public Drops reserveStockForOrder(Long dropId, Long productId, int quantity) {
+    if (quantity <= 0) {
+      throw new DropsException(ErrorCode.INVALID_DROP_ORDER_QUANTITY);
+    }
+
     Drops drops = dropsService.findById(dropId);
 
     if (!drops.isActive()) {

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
@@ -185,4 +185,31 @@ public class DropsFacadeService {
       log.info("드랍 ID={} 재활성화가 동시성 충돌로 스킵되었습니다.", dropId, e);
     }
   }
+
+  /**
+   * 주문 생성을 위해 드랍 재고를 선점(차감)한다.
+   *
+   * @param dropId 드랍 ID
+   * @param productId 상품 ID
+   * @param quantity 구매 수량
+   * @return 재고 차감이 반영된 드랍
+   */
+  @Transactional
+  public Drops reserveStockForOrder(Long dropId, Long productId, int quantity) {
+    Drops drops = dropsService.findById(dropId);
+
+    if (!drops.isActive()) {
+      throw new DropsException(ErrorCode.DROP_ORDER_NOT_ALLOWED);
+    }
+    if (!drops.getProduct().getId().equals(productId)) {
+      throw new DropsException(ErrorCode.DROP_PRODUCT_MISMATCH);
+    }
+
+    drops.decrementRemainStock(quantity);
+    if (drops.getRemainStock() <= 0L) {
+      drops.finish();
+      productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+    }
+    return drops;
+  }
 }

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsService.java
@@ -59,19 +59,19 @@ public class DropsService {
       throw new DropsException(ErrorCode.DROP_ACTIVE_UPDATE_LOCKED);
     }
 
-    LocalDateTime updatedStartAt = request.getStartAt() == null
+    final LocalDateTime updatedStartAt = request.getStartAt() == null
         ? drops.getStartAt()
         : request.getStartAt();
-    LocalDateTime updatedEndAt = request.getEndAt() == null
+    final LocalDateTime updatedEndAt = request.getEndAt() == null
         ? drops.getEndAt()
         : request.getEndAt();
-    Long updatedTotalStock = request.getTotalStock() == null
+    final Long updatedTotalStock = request.getTotalStock() == null
         ? drops.getTotalStock()
         : request.getTotalStock();
-    Long updatedPurchaseLimit = request.getPurchaseLimit() == null
+    final Long updatedPurchaseLimit = request.getPurchaseLimit() == null
         ? drops.getPurchaseLimit()
         : request.getPurchaseLimit();
-    boolean updatedUseQueue = request.getUseQueue() == null
+    final boolean updatedUseQueue = request.getUseQueue() == null
         ? drops.isUseQueue()
         : request.getUseQueue();
 
@@ -157,7 +157,8 @@ public class DropsService {
    */
   @Transactional(readOnly = true)
   public Map<Long, Drops> findLatestDropsByProductIds(Collection<Long> productIds) {
-    List<Drops> dropsList = dropsRepository.findAllByProductIdInOrderByProductIdAscStartAtDesc(productIds);
+    List<Drops> dropsList =
+        dropsRepository.findAllByProductIdInOrderByProductIdAscStartAtDesc(productIds);
     Map<Long, Drops> latestDrops = new HashMap<>();
     for (Drops drops : dropsList) {
       latestDrops.putIfAbsent(drops.getProduct().getId(), drops);
@@ -185,5 +186,4 @@ public class DropsService {
     }
   }
 }
-
 

--- a/src/main/java/com/example/dropshop/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/product/controller/ProductQueryController.java
@@ -34,8 +34,7 @@ public class ProductQueryController {
           @RequestParam(required = false) String status,
           @RequestParam(required = false, defaultValue = "LATEST") String sort,
           @RequestParam(defaultValue = "0") int page,
-          @RequestParam(defaultValue = "20") int size
-      ) {
+          @RequestParam(defaultValue = "20") int size) {
     Pageable pageable = PageRequest.of(page, size);
     Page<ProductListItemResponse> response = productFacadeService.findPublicProducts(
         status,

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/PresignedUrlIssueRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/PresignedUrlIssueRequest.java
@@ -3,7 +3,6 @@ package com.example.dropshop.domain.product.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 이미지 Presigned URL 발급 요청 DTO.
@@ -15,4 +14,3 @@ public class PresignedUrlIssueRequest {
   @Size(max = 20)
   private String fileType;
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 등록 요청 DTO.
@@ -65,4 +64,3 @@ public class ProductCreateRequest {
     private Boolean isThumbnail;
   }
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageCreateRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 이미지 추가 요청 DTO.
@@ -24,4 +23,3 @@ public class ProductImageCreateRequest {
   @NotNull
   private Boolean isThumbnail;
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductImageUpdateRequest.java
@@ -2,7 +2,6 @@ package com.example.dropshop.domain.product.dto.request;
 
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 이미지 수정 요청 DTO.
@@ -15,4 +14,3 @@ public class ProductImageUpdateRequest {
 
   private Boolean isThumbnail;
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductStatusUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductStatusUpdateRequest.java
@@ -3,7 +3,6 @@ package com.example.dropshop.domain.product.dto.request;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 상태 변경 요청 DTO.
@@ -14,4 +13,3 @@ public class ProductStatusUpdateRequest {
   @NotNull
   private ProductStatus status;
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductUpdateRequest.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 상품 정보 수정 요청 DTO.
@@ -37,4 +36,3 @@ public class ProductUpdateRequest {
   @Size(min = 1)
   private String specification;
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/exception/ProductException.java
+++ b/src/main/java/com/example/dropshop/domain/product/exception/ProductException.java
@@ -22,6 +22,13 @@ public class ProductException extends ServiceException {
     this.errorCode = errorCode;
   }
 
+  /**
+   * 에러 코드와 사용자 메시지로 상품 예외를 생성한다.
+   *
+   * @param errorCode 공통 에러 코드
+   * @param message 상세 메시지
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
   public ProductException(ErrorCode errorCode, String message) {
     super(errorCode, message);
     this.errorCode = errorCode;

--- a/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/dropshop/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -10,8 +10,8 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -106,5 +106,3 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
         );
   }
 }
-
-

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
@@ -277,7 +277,11 @@ public class ProductCommandService {
         .orElseThrow(() -> new ProductException(ErrorCode.PRODUCT_IMAGE_NOT_FOUND));
   }
 
-  private ProductImage findImageByUrlAndSortOrder(Product product, String imageUrl, Integer sortOrder) {
+  private ProductImage findImageByUrlAndSortOrder(
+      Product product,
+      String imageUrl,
+      Integer sortOrder
+  ) {
     return product.getImages().stream()
         .filter(image -> image.getImageUrl().equals(imageUrl)
             && image.getSortOrder() == sortOrder)
@@ -304,4 +308,3 @@ public class ProductCommandService {
         .getImageUrl();
   }
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductImageUploadProperties.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductImageUploadProperties.java
@@ -17,6 +17,16 @@ public class ProductImageUploadProperties {
   private final String cdnBaseUrl;
   private final long presignedExpirationSeconds;
 
+  /**
+   * 상품 이미지 업로드 설정값을 생성한다.
+   *
+   * @param bucket S3 버킷명
+   * @param region AWS 리전
+   * @param keyPrefix 오브젝트 키 prefix
+   * @param cdnBaseUrl CDN 베이스 URL
+   * @param presignedExpirationSeconds Presigned URL 만료 시간(초)
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
   public ProductImageUploadProperties(
       @DefaultValue("") String bucket,
       @DefaultValue("ap-northeast-2") String region,
@@ -31,4 +41,3 @@ public class ProductImageUploadProperties {
     this.presignedExpirationSeconds = presignedExpirationSeconds;
   }
 }
-

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductPolicyProperties.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductPolicyProperties.java
@@ -14,6 +14,13 @@ public class ProductPolicyProperties {
   private final String deliveryInfo;
   private final String refundPolicy;
 
+  /**
+   * 상품 공통 정책 설정값을 생성한다.
+   *
+   * @param deliveryInfo 배송 정책 문구
+   * @param refundPolicy 환불 정책 문구
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
   public ProductPolicyProperties(
       @DefaultValue("Common delivery policy") String deliveryInfo,
       @DefaultValue("Common refund policy") String refundPolicy

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
@@ -1,5 +1,6 @@
 package com.example.dropshop.domain.product.service;
 
+import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.service.DropsFacadeService;
 import com.example.dropshop.domain.product.config.ProductConstraints;
@@ -10,7 +11,6 @@ import com.example.dropshop.domain.product.entity.Product;
 import com.example.dropshop.domain.product.enums.ProductListSortType;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.exception.ProductException;
-import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.domain.product.repository.ProductRepository;
 import com.example.dropshop.domain.user.entity.User;
 import com.example.dropshop.domain.user.service.UserFacadeService;
@@ -179,7 +179,3 @@ public class ProductQueryService {
     return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
   }
 }
-
-
-
-

--- a/src/main/java/com/example/dropshop/domain/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/user/service/UserFacadeService.java
@@ -25,6 +25,17 @@ public class UserFacadeService {
   }
 
   /**
+   * 이메일로 사용자 정보를 조회한다.
+   *
+   * @param email 사용자 이메일
+   * @return 사용자 정보(Optional)
+   */
+  @Transactional(readOnly = true)
+  public Optional<User> findByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
+
+  /**
    * 이메일로 사용자 ID를 조회한다.
    *
    * @param email 사용자 이메일
@@ -32,9 +43,8 @@ public class UserFacadeService {
    */
   @Transactional(readOnly = true)
   public Long getUserIdByEmail(String email) {
-    return userRepository.findByEmail(email)
+    return findByEmail(email)
         .orElseThrow(() -> new IllegalArgumentException("인증된 사용자를 찾을 수 없습니다."))
         .getId();
   }
 }
-


### PR DESCRIPTION
## 📌 PR 제목
refactor: Product/Drops 파사드 누락 메서드 복구 및 컴파일/스타일 정리

---

## ✨ 변경 사항
이번 PR에서는 Product/Drops 리팩토링 과정에서 누락된 파사드 메서드를 복구하고, 연쇄적으로 발생한 컴파일 오류 및 체크스타일 이슈를 정리했습니다.

### 1) 컴파일 오류 수정
- `UserFacadeService`에 `findByEmail(String)` 메서드 복구
  - `SellerAuthResolver`에서 이메일 기반 사용자 조회 시 `cannot find symbol` 오류 해결
- `DropsFacadeService`에 `reserveStockForOrder(Long dropId, Long productId, int quantity)` 메서드 추가
  - `OrderFacadeService`에서 호출하던 누락 시그니처 복구
  - 드랍 ACTIVE 상태 검증, 상품 일치 검증, 재고 차감 및 품절 전이 처리 포함

### 2) 리팩토링 정합성 보완
- `UserFacadeService#getUserIdByEmail`이 `findByEmail`을 재사용하도록 정리
- Order ↔ Drops 연동 시 파사드 경유 흐름이 깨지지 않도록 인터페이스 정합성 맞춤

### 3) 체크스타일/코드 품질 정리
- Product/Drops 도메인 중심으로 import 정렬, 중복 import 제거
- Javadoc first sentence period 누락 보완
- line length, indentation, 불필요 공백/unused import 정리
- 일부 긴 시그니처/체인 호출 줄바꿈 적용

---

## ✅ 체크리스트
- [x] 컴파일 오류 재현 및 원인 파악 완료
- [x] 누락된 파사드 메서드 복구 완료
- [x] Product/Drops 도메인 체크스타일 주요 이슈 정리
- [x] 기존 도메인 규칙(드랍 상태/재고 차감) 위반 없이 보완

---

## 🧪 테스트
- `./gradlew.bat compileJava` 기준 컴파일 통과 확인
- 기존 오류:
  - `findByEmail(String)` missing
  - `reserveStockForOrder(Long, Long, int)` missing
- 수정 후 위 2건 symbol 오류 해소

---

## 💡 참고 사항
- 이번 PR은 기능 추가보다 **리팩토링 누락 복구 + 안정화**에 초점을 맞췄습니다.
- JWT 인증 전환/헤더 제거 등은 팀 공통 인증 정책과 맞춰 후속 PR에서 일괄 반영 예정입니다.
- 로컬 환경/브랜치 상태에 따라 동일 오류가 재발할 수 있어, 최신 브랜치 동기화 후 빌드 확인이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 시 드롭 상품 재고를 예약하는 기능 추가
  * 이메일로 사용자를 조회하는 조회 메서드 추가

* **개선사항**
  * 예외 생성자 확장으로 사용자 정의 오류 메시지 지원 (드롭/상품)
  * 잘못된 주문 수량에 대한 오류 코드 추가(수량은 1 이상)
  * 생성자·메서드 문서화 강화 및 코드 포맷/임포트 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->