### PR TITLE
feat : 배송·환불 정책을 DB 기반으로 전환하고 판매자 커스텀 입력 지원

### DIFF
--- a/src/main/java/com/example/dropshop/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/SecurityConfig.java
@@ -32,6 +32,9 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능한 경로
                         .requestMatchers("/api/auth/login", "/api/auth/refresh").permitAll()
                         .requestMatchers("/api/users/signup").permitAll()
+                        // 관리자 전용 경로
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        // 판매자 전용 경로
                         .requestMatchers("/api/sellers/drops/**").hasRole("SELLER")
                         .requestMatchers("/api/sellers/products/**").hasRole("SELLER")
                         .requestMatchers("/api/sellers/images/**").hasRole("SELLER")

--- a/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/dropshop/common/exception/ErrorCode.java
@@ -54,8 +54,9 @@ public enum ErrorCode {
   PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 이미지를 찾을 수 없습니다."),
   THUMBNAIL_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "대표 이미지는 삭제할 수 없습니다."),
   IMAGE_MIN_REQUIRED(HttpStatus.BAD_REQUEST, "이미지는 최소 1개 이상 유지해야 합니다."),
-  INVALID_STOCK(HttpStatus.BAD_REQUEST, "상품 재고는 0보다 커야 합니다."),
-  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값 검증에 실패했습니다."),
+   INVALID_STOCK(HttpStatus.BAD_REQUEST, "상품 재고는 0보다 커야 합니다."),
+   PRODUCT_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정책을 찾을 수 없습니다."),
+   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값 검증에 실패했습니다."),
 
   /**
    * Drop.

--- a/src/main/java/com/example/dropshop/domain/product/common/controller/ProductPolicyController.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/controller/ProductPolicyController.java
@@ -5,6 +5,7 @@ import com.example.dropshop.domain.product.common.dto.ProductPolicyUpdateRequest
 import com.example.dropshop.domain.product.common.enums.ProductPolicyType;
 import com.example.dropshop.domain.product.common.service.ProductPolicyService;
 import jakarta.validation.Valid;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -95,7 +96,7 @@ public class ProductPolicyController {
   ) {
     log.info("정책 조회 요청 (type={})", policyType);
     try {
-      ProductPolicyType type = ProductPolicyType.valueOf(policyType.toUpperCase());
+      ProductPolicyType type = ProductPolicyType.valueOf(policyType.toUpperCase(Locale.ROOT));
       String content = policyService.getPolicyByType(type);
       ProductPolicyResponse response = ProductPolicyResponse.builder()
           .policyType(type.name())

--- a/src/main/java/com/example/dropshop/domain/product/common/controller/ProductPolicyController.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/controller/ProductPolicyController.java
@@ -1,0 +1,111 @@
+package com.example.dropshop.domain.product.common.controller;
+
+import com.example.dropshop.domain.product.common.dto.ProductPolicyResponse;
+import com.example.dropshop.domain.product.common.dto.ProductPolicyUpdateRequest;
+import com.example.dropshop.domain.product.common.enums.ProductPolicyType;
+import com.example.dropshop.domain.product.common.service.ProductPolicyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 상품 공통 정책 관리 API (관리자 전용)
+ * DB에서 정책을 조회하고 수정하는 엔드포인트를 제공한다.
+ */
+@RestController
+@RequestMapping("/api/admin/product-policies")
+@RequiredArgsConstructor
+@Slf4j
+public class ProductPolicyController {
+
+  private final ProductPolicyService policyService;
+
+  /**
+   * 배송 정책을 조회한다.
+   * GET /api/admin/product-policies/delivery
+   */
+  @GetMapping("/delivery")
+  public ResponseEntity<ProductPolicyResponse> getDeliveryPolicy() {
+    log.info("배송 정책 조회 요청");
+    String content = policyService.getDeliveryInfo();
+    ProductPolicyResponse response = ProductPolicyResponse.builder()
+        .policyType("DELIVERY")
+        .content(content)
+        .build();
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 환불 정책을 조회한다.
+   * GET /api/admin/product-policies/refund
+   */
+  @GetMapping("/refund")
+  public ResponseEntity<ProductPolicyResponse> getRefundPolicy() {
+    log.info("환불 정책 조회 요청");
+    String content = policyService.getRefundPolicy();
+    ProductPolicyResponse response = ProductPolicyResponse.builder()
+        .policyType("REFUND")
+        .content(content)
+        .build();
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 배송 정책을 수정한다.
+   * PUT /api/admin/product-policies/delivery
+   */
+  @PutMapping("/delivery")
+  public ResponseEntity<ProductPolicyResponse> updateDeliveryPolicy(
+      @Valid @RequestBody ProductPolicyUpdateRequest request
+  ) {
+    log.info("배송 정책 수정 요청");
+    var updated = policyService.updatePolicy(ProductPolicyType.DELIVERY, request.getContent());
+    return ResponseEntity.status(HttpStatus.OK).body(ProductPolicyResponse.from(updated));
+  }
+
+  /**
+   * 환불 정책을 수정한다.
+   * PUT /api/admin/product-policies/refund
+   */
+  @PutMapping("/refund")
+  public ResponseEntity<ProductPolicyResponse> updateRefundPolicy(
+      @Valid @RequestBody ProductPolicyUpdateRequest request
+  ) {
+    log.info("환불 정책 수정 요청");
+    var updated = policyService.updatePolicy(ProductPolicyType.REFUND, request.getContent());
+    return ResponseEntity.status(HttpStatus.OK).body(ProductPolicyResponse.from(updated));
+  }
+
+  /**
+   * 특정 정책 유형의 정책을 조회한다.
+   * GET /api/admin/product-policies/{policyType}
+   * 잘못된 policyType (DELIVERY, REFUND 아닌 값)일 경우 400 Bad Request 반환
+   */
+  @GetMapping("/{policyType}")
+  public ResponseEntity<ProductPolicyResponse> getPolicyByType(
+      @PathVariable String policyType
+  ) {
+    log.info("정책 조회 요청 (type={})", policyType);
+    try {
+      ProductPolicyType type = ProductPolicyType.valueOf(policyType.toUpperCase());
+      String content = policyService.getPolicyByType(type);
+      ProductPolicyResponse response = ProductPolicyResponse.builder()
+          .policyType(type.name())
+          .content(content)
+          .build();
+      return ResponseEntity.ok(response);
+    } catch (IllegalArgumentException e) {
+      log.warn("잘못된 정책 유형: {}", policyType);
+      return ResponseEntity.badRequest().build();
+    }
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/dto/ProductPolicyResponse.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/dto/ProductPolicyResponse.java
@@ -1,0 +1,40 @@
+package com.example.dropshop.domain.product.common.dto;
+
+import com.example.dropshop.domain.product.common.entity.ProductPolicy;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 상품 공통 정책 응답 DTO
+ */
+@Getter
+@Builder
+public class ProductPolicyResponse {
+
+  @JsonProperty("id")
+  private Long id;
+
+  @JsonProperty("policyType")
+  private String policyType;
+
+  @JsonProperty("content")
+  private String content;
+
+  @JsonProperty("modifiedAt")
+  private LocalDateTime modifiedAt;
+
+  /**
+   * ProductPolicy 엔티티를 DTO로 변환한다.
+   */
+  public static ProductPolicyResponse from(ProductPolicy policy) {
+    return ProductPolicyResponse.builder()
+        .id(policy.getId())
+        .policyType(policy.getPolicyType().name())
+        .content(policy.getContent())
+        .modifiedAt(policy.getModifiedAt())
+        .build();
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/dto/ProductPolicyUpdateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/dto/ProductPolicyUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.dropshop.domain.product.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 상품 공통 정책 수정 Request DTO
+ */
+@Getter
+public class ProductPolicyUpdateRequest {
+
+  @NotBlank(message = "정책 내용은 필수입니다")
+  @JsonProperty("content")
+  private String content;
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/entity/ProductPolicy.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/entity/ProductPolicy.java
@@ -1,0 +1,77 @@
+package com.example.dropshop.domain.product.common.entity;
+
+import com.example.dropshop.common.entity.BaseEntity;
+import com.example.dropshop.domain.product.common.enums.ProductPolicyType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 상품 공통 정책(배송, 환불)을 DB에서 관리하는 엔티티.
+ * 서버 재시작 없이 정책을 변경할 수 있도록 설계됨.
+ */
+@Getter
+@Entity
+@Table(
+    name = "product_policies",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = "policy_type", name = "uk_product_policies_type")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductPolicy extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /**
+   * 정책 유형 (DELIVERY, REFUND)
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "policy_type", nullable = false, length = 20)
+  private ProductPolicyType policyType;
+
+  /**
+   * 정책 내용.
+   */
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  /**
+   * 정책 생성자.
+   */
+  @Builder(access = AccessLevel.PRIVATE)
+  private ProductPolicy(ProductPolicyType policyType, String content) {
+    this.policyType = policyType;
+    this.content = content;
+  }
+
+  /**
+   * 상품 공통 정책을 생성한다.
+   */
+  public static ProductPolicy create(ProductPolicyType policyType, String content) {
+    return ProductPolicy.builder()
+        .policyType(policyType)
+        .content(content)
+        .build();
+  }
+
+  /**
+   * 정책 내용을 수정한다.
+   */
+  public void updateContent(String newContent) {
+    this.content = newContent;
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/enums/ProductPolicyType.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/enums/ProductPolicyType.java
@@ -1,0 +1,17 @@
+package com.example.dropshop.domain.product.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 상품 공통 정책 유형.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ProductPolicyType {
+  DELIVERY("배송 정책"),
+  REFUND("환불 정책");
+
+  private final String description;
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/repository/ProductPolicyRepository.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/repository/ProductPolicyRepository.java
@@ -1,0 +1,20 @@
+package com.example.dropshop.domain.product.common.repository;
+
+import com.example.dropshop.domain.product.common.entity.ProductPolicy;
+import com.example.dropshop.domain.product.common.enums.ProductPolicyType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 상품 공통 정책 저장소
+ */
+@Repository
+public interface ProductPolicyRepository extends JpaRepository<ProductPolicy, Long> {
+
+  /**
+   * 정책 유형으로 정책을 조회한다.
+   */
+  Optional<ProductPolicy> findByPolicyType(ProductPolicyType policyType);
+}
+

--- a/src/main/java/com/example/dropshop/domain/product/common/service/ProductPolicyService.java
+++ b/src/main/java/com/example/dropshop/domain/product/common/service/ProductPolicyService.java
@@ -1,0 +1,92 @@
+package com.example.dropshop.domain.product.common.service;
+
+import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.product.common.entity.ProductPolicy;
+import com.example.dropshop.domain.product.common.enums.ProductPolicyType;
+import com.example.dropshop.domain.product.common.repository.ProductPolicyRepository;
+import com.example.dropshop.domain.product.exception.ProductException;
+import com.example.dropshop.domain.product.service.ProductPolicyProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 상품 공통 정책을 관리하는 서비스.
+ * DB에서 정책을 직접 조회한다.
+ * 정책 값이 없으면 application.yml의 기본값을 fallback으로 사용한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ProductPolicyService {
+
+  private final ProductPolicyRepository policyRepository;
+  private final ProductPolicyProperties policyProperties;
+
+  /**
+   * 배송 정책을 조회한다.
+   * 편의 메서드 - 내부적으로 getPolicyByType(DELIVERY) 호출
+   */
+  public String getDeliveryInfo() {
+    return getPolicyByType(ProductPolicyType.DELIVERY);
+  }
+
+  /**
+   * 환불 정책을 조회한다.
+   * 편의 메서드 - 내부적으로 getPolicyByType(REFUND) 호출
+   */
+  public String getRefundPolicy() {
+    return getPolicyByType(ProductPolicyType.REFUND);
+  }
+
+  /**
+   * 특정 유형의 정책을 조회한다. (핵심 메서드)
+   * DB에 없으면 yml의 기본값을 반환한다.
+   */
+  public String getPolicyByType(ProductPolicyType policyType) {
+    return policyRepository.findByPolicyType(policyType)
+        .map(ProductPolicy::getContent)
+        .orElseGet(() -> {
+          log.info("정책 조회 실패 (type={}), 기본값 사용", policyType.name());
+          return switch (policyType) {
+            case DELIVERY -> policyProperties.getDeliveryInfo();
+            case REFUND -> policyProperties.getRefundPolicy();
+          };
+        });
+  }
+
+  /**
+   * 정책을 수정한다.
+   */
+  @Transactional
+  public ProductPolicy updatePolicy(ProductPolicyType policyType, String newContent) {
+    ProductPolicy policy = policyRepository.findByPolicyType(policyType)
+        .orElseThrow(() -> new ProductException(
+            ErrorCode.PRODUCT_POLICY_NOT_FOUND,
+            String.format("정책을 찾을 수 없습니다 (type=%s)", policyType.name())
+        ));
+
+    policy.updateContent(newContent);
+    log.info("정책 수정 완료 (type={})", policyType.name());
+    return policy;
+  }
+
+  /**
+   * 정책을 생성하거나 기존값을 업데이트한다.
+   * seeding 및 관리자 초기화 시 사용.
+   */
+  @Transactional
+  public ProductPolicy saveOrUpdatePolicy(ProductPolicyType policyType, String content) {
+    ProductPolicy policy = policyRepository.findByPolicyType(policyType)
+        .map(existing -> {
+          existing.updateContent(content);
+          return existing;
+        })
+        .orElseGet(() -> ProductPolicy.create(policyType, content));
+    ProductPolicy saved = policyRepository.save(policy);
+    log.info("정책 저장/수정 완료 (type={}, id={})", policyType.name(), saved.getId());
+    return saved;
+  }
+}

--- a/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/example/dropshop/domain/product/dto/request/ProductCreateRequest.java
@@ -41,6 +41,16 @@ public class ProductCreateRequest {
   @NotBlank
   private String specification;
 
+  /**
+   * 배송 안내. 입력하지 않으면 공통 기본 배송 정책이 적용된다.
+   */
+  private String deliveryInfo;
+
+  /**
+   * 환불 정책. 입력하지 않으면 공통 기본 환불 정책이 적용된다.
+   */
+  private String refundPolicy;
+
   @Valid
   @NotEmpty
   @Size(max = 5)

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
@@ -1,6 +1,7 @@
 package com.example.dropshop.domain.product.service;
 
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.product.common.service.ProductPolicyService;
 import com.example.dropshop.domain.product.dto.request.ProductCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageUpdateRequest;
@@ -28,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductCommandService {
 
   private final ProductRepository productRepository;
-  private final ProductPolicyProperties policyProperties;
+  private final ProductPolicyService productPolicyService;
   private final ProductValidator productValidator;
 
   /**
@@ -54,8 +55,12 @@ public class ProductCommandService {
         extractThumbnailUrl(request),
         request.getDescription(),
         request.getSpecification(),
-        policyProperties.getDeliveryInfo(),
-        policyProperties.getRefundPolicy()
+        request.getDeliveryInfo() != null
+            ? request.getDeliveryInfo()
+            : productPolicyService.getDeliveryInfo(),
+        request.getRefundPolicy() != null
+            ? request.getRefundPolicy()
+            : productPolicyService.getRefundPolicy()
     );
 
     request.getImages().stream()

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * 상품 쓰기 도메인 서비스.
@@ -55,11 +56,11 @@ public class ProductCommandService {
         extractThumbnailUrl(request),
         request.getDescription(),
         request.getSpecification(),
-        request.getDeliveryInfo() != null
-            ? request.getDeliveryInfo()
+        StringUtils.hasText(request.getDeliveryInfo())
+            ? request.getDeliveryInfo().trim()
             : productPolicyService.getDeliveryInfo(),
-        request.getRefundPolicy() != null
-            ? request.getRefundPolicy()
+        StringUtils.hasText(request.getRefundPolicy())
+            ? request.getRefundPolicy().trim()
             : productPolicyService.getRefundPolicy()
     );
 

--- a/src/main/resources/db/migration/V10__create_product_policies_table.sql
+++ b/src/main/resources/db/migration/V10__create_product_policies_table.sql
@@ -1,0 +1,28 @@
+-- 상품 공통 정책 테이블 생성
+CREATE TABLE IF NOT EXISTS product_policies (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '정책 ID',
+  policy_type VARCHAR(20) NOT NULL COMMENT '정책 유형 (DELIVERY, REFUND)',
+  content LONGTEXT NOT NULL COMMENT '정책 내용',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시간',
+  CONSTRAINT uk_product_policies_type UNIQUE (policy_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='상품 공통 정책 (배송, 환불)';
+
+-- 초기 배송 정책 데이터
+INSERT INTO product_policies (policy_type, content)
+VALUES (
+  'DELIVERY',
+  '기본 배송 정책을 입력하세요'
+)
+ON DUPLICATE KEY UPDATE
+  content = VALUES(content);
+
+-- 초기 환불 정책 데이터
+INSERT INTO product_policies (policy_type, content)
+VALUES (
+  'REFUND',
+  '기본 환불 정책을 입력하세요'
+)
+ON DUPLICATE KEY UPDATE
+  content = VALUES(content);
+

--- a/src/main/resources/db/migration/V10__create_product_policies_table.sql
+++ b/src/main/resources/db/migration/V10__create_product_policies_table.sql
@@ -15,7 +15,7 @@ VALUES (
   '기본 배송 정책을 입력하세요'
 )
 ON DUPLICATE KEY UPDATE
-  content = VALUES(content);
+  content = content;
 
 -- 초기 환불 정책 데이터
 INSERT INTO product_policies (policy_type, content)
@@ -24,5 +24,5 @@ VALUES (
   '기본 환불 정책을 입력하세요'
 )
 ON DUPLICATE KEY UPDATE
-  content = VALUES(content);
+  content = content;
 

--- a/src/test/java/com/example/dropshop/domain/product/service/ProductCommandServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/product/service/ProductCommandServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.domain.product.common.service.ProductPolicyService;
 import com.example.dropshop.domain.product.dto.request.ProductCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageCreateRequest;
 import com.example.dropshop.domain.product.dto.request.ProductImageUpdateRequest;
@@ -39,16 +40,21 @@ class ProductCommandServiceTest {
   private ProductRepository productRepository;
 
   @Mock
+  private ProductPolicyService productPolicyService;
+
+  @Mock
   private ProductValidator productValidator;
 
   private ProductCommandService productCommandService;
 
   @BeforeEach
   void setUp() {
-    ProductPolicyProperties policyProperties =
-        new ProductPolicyProperties("기본 배송 정책", "기본 환불 정책");
     productCommandService =
-        new ProductCommandService(productRepository, policyProperties, productValidator);
+        new ProductCommandService(productRepository, productPolicyService, productValidator);
+
+    // 기본 정책값 mock 설정
+    given(productPolicyService.getDeliveryInfo()).willReturn("기본 배송 정책");
+    given(productPolicyService.getRefundPolicy()).willReturn("기본 환불 정책");
   }
 
   @Test


### PR DESCRIPTION
## 📌 PR 제목
feat: 상품 기본 배송/환불 정책 DB 관리 전환 및 상품 생성 시 선택 입력 지원

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `productCommon` 패키지 신설 후 기본 배송/환불 정책을 DB에서 관리하도록 전환
  - `ProductPolicy` 엔티티, `ProductPolicyType` enum, `ProductPolicyRepository`, `ProductPolicyService`, `ProductPolicyController` 추가
- Flyway 마이그레이션 추가
  - `V10__create_product_policies_table.sql`로 `product_policies` 테이블 생성 및 초기 정책 데이터(DELIVERY/REFUND) 시딩
- 상품 생성 요청 확장
  - `ProductCreateRequest`에 `deliveryInfo`, `refundPolicy` 선택 필드 추가
- 상품 생성 정책 적용 로직 개선
  - 판매자가 `deliveryInfo`/`refundPolicy`를 입력하면 입력값 사용
  - 미입력 시 DB 기본 정책 조회값 자동 적용

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

- close #이슈번호

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] 빌드/컴파일 테스트 완료 (`./gradlew build -x test`, `./gradlew compileJava`)
- [x] 정책 서비스 통합 테스트 확인 (`ProductPolicyServiceIntegrationTest`)
- [ ] Postman 테스트 완료
- [x] 예외 처리 확인 (`policyType` 잘못된 값 요청 시 400)

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

- `ProductCreateRequest`의 `deliveryInfo`, `refundPolicy`는 선택 입력 필드입니다.
- 정책 적용 우선순위
  1) 요청값 존재 시 요청값 사용  
  2) 요청값 미존재 시 DB 기본 정책 사용
- 정책 기본값은 `product_policies` 테이블에서 관리하며, 운영 중 API로 수정 가능합니다.
- 기존 `application.yml`의 `product.policy.*` 값은 DB 정책이 없는 예외 상황에서 fallback 용도로만 사용됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 정책(배송·반품) 관리 시스템 추가 및 DB 테이블과 초기 데이터 생성
  * 관리자용 상품정책 조회·수정 API(배송·반품 별도 엔드포인트) 추가

* **변경 사항**
  * 상품 생성 시 요청값의 배송정보·반품정책을 우선 사용하고 없으면 공통 정책으로 대체
  * 관리자 경로(/api/admin/**)에 ADMIN 권한 요구 추가

* **테스트**
  * 정책 서비스 목(mock) 적용으로 관련 서비스 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->