### PR TITLE
test: 판매자,유저,어쓰 관련 통합 테스트 코드 대폭 수정

### DIFF
--- a/src/main/java/com/example/dropshop/common/config/LocalSellerTestDataInitializer.java
+++ b/src/main/java/com/example/dropshop/common/config/LocalSellerTestDataInitializer.java
@@ -25,6 +25,9 @@ public class LocalSellerTestDataInitializer {
     private static final String TEST_BRAND_NAME = "Dropshop Test Brand";
     private static final String TEST_BRAND_LOGO = "https://cdn.example.com/test-brand-logo.png";
     private static final String TEST_ACCOUNT_INFO = "국민은행 123-456-789012";
+    private static final String TEST_COMPANY_NAME = "드랍샵 테스트 법인";
+    private static final String TEST_REPRESENTATIVE_NAME = "홍길동";
+    private static final String TEST_PHONE_NUMBER = "010-1234-5678";
 
     @Bean
     CommandLineRunner initLocalSellerTestData(
@@ -60,6 +63,9 @@ public class LocalSellerTestDataInitializer {
                     .brandName(TEST_BRAND_NAME)
                     .brandLogo(TEST_BRAND_LOGO)
                     .accountInfo(TEST_ACCOUNT_INFO)
+                    .companyName(TEST_COMPANY_NAME)
+                    .representativeName(TEST_REPRESENTATIVE_NAME)
+                    .phoneNumber(TEST_PHONE_NUMBER)
                     .build());
         }
 

--- a/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerApplyRequest.java
+++ b/src/main/java/com/example/dropshop/domain/seller/dto/request/SellerApplyRequest.java
@@ -1,5 +1,7 @@
 package com.example.dropshop.domain.seller.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,12 +9,25 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SellerApplyRequest {
+    @NotBlank(message = "회사명을 입력해주세요.")
     private String companyName;
+
+    @NotBlank(message = "대표자명을 입력해주세요.")
     private String representativeName;
+
+    @NotBlank(message = "사업자 번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{10}$", message = "사업자 번호는 숫자 10자리여야 합니다.")
     private String businessNo;
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
     private String phoneNumber;
+
+    @NotBlank(message = "브랜드명을 입력해주세요.")
     private String brandName;
+
     private String brandLogo;
+
+    @NotBlank(message = "정산 계좌 정보를 입력해주세요.")
     private String accountInfo; // ✅ 이번에 터진 필드 추가
 
     // 생성자 (모든 필드 포함)

--- a/src/test/java/com/example/dropshop/domain/seller/controller/SellerControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/seller/controller/SellerControllerTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -53,15 +53,14 @@ class SellerControllerTest {
         HandlerMethodArgumentResolver mockAuthResolver = new HandlerMethodArgumentResolver() {
             @Override
             public boolean supportsParameter(MethodParameter parameter) {
-                return parameter.getParameterType().isAssignableFrom(UserDetails.class);
+                return parameter.getParameterType().equals(String.class)
+                        && parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
             }
 
             @Override
             public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                           NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-                UserDetails mockUser = Mockito.mock(UserDetails.class);
-                given(mockUser.getUsername()).willReturn("test@example.com");
-                return mockUser;
+                return "test@example.com";
             }
         };
 
@@ -84,6 +83,9 @@ class SellerControllerTest {
 
         // CodeRabbit 지적 반영: brandLogoUrl -> brandLogo 로 수정
         String jsonContent = "{" +
+                "\"companyName\":\"테스트법인\"," +
+                "\"representativeName\":\"홍길동\"," +
+                "\"phoneNumber\":\"01012345678\"," +
                 "\"businessNo\":\"1234567890\"," +
                 "\"brandName\":\"드랍숍\"," +
                 "\"brandLogo\":\"logo.png\"," +


### PR DESCRIPTION
## 📌 PR 제목
test: 판매자,유저,어쓰 관련 통합 테스트 코드 대폭 수정

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

1. SellerControllerTest.java (테스트 코드 정상화)
ArgumentResolver 수정:
supportsParameter에서 UserDetails.class 대신 String.class와 @AuthenticationPrincipal 어노테이션을 체크하도록 변경하여 실제 컨트롤러 로직과 일치시켰습니다.
resolveArgument 시 Mock 객체 대신 실제 테스트용 이메일 문자열("test@example.com")을 반환하도록 수정하여 PotentialStubbingProblem(email null) 에러를 해결했습니다.
테스트 데이터 보완:
applySeller_Success 테스트의 JSON 바디에 @NotBlank 제약 조건이 추가된 companyName, representativeName, phoneNumber 필드를 추가하여 400 에러를 방지했습니다.
2. SellerApplyRequest.java (검증 로직 강화)
Validation 추가: 필드 누락 시 400 Bad Request가 정상적으로 발생하도록 필수 필드에 @NotBlank 어노테이션을 추가했습니다.
3. Seller 엔티티 및 테스트 데이터 초기화 (DB 정합성)
LocalSellerTestDataInitializer.java 수정:
dev 브랜치 변경 사항 반영으로 인해 Seller 엔티티에 nullable = false로 추가된 companyName, representativeName, phoneNumber 필드가 빌더 패턴에서 누락되었던 문제를 해결했습니다.
테스트 데이터 생성 시 해당 필드들을 추가하여 DataIntegrityViolationException(Column cannot be null) 에러를 해결했습니다.


---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.


---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 판매자 신청 폼의 데이터 검증 강화. 회사명, 대표자명, 전화번호 등 필수 항목을 검증하고 사업자번호는 10자리 숫자 형식으로 제한합니다.

* **Tests**
  * 신청 폼 유효성 검사에 대한 테스트 코드 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->