### PR TITLE
feat: 상태 전이 시 Kafka drops.status.changed 이벤트 발행 추가

### DIFF
--- a/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
@@ -1,8 +1,7 @@
 package com.example.dropshop.common.config.kafka.produce;
 
+import com.example.dropshop.domain.drops.event.DropStatusChangedEvent;
 import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -26,27 +25,31 @@ public class KafkaProducerConfig {
   @Value("${spring.kafka.bootstrap-servers}")
   private String bootstrapServers;
 
-  // PaymentCompletedEvent ProducerFactory
-
-  @Bean
-  public ProducerFactory<String, ThreadHoldResponse> eventProducerFactory() {
+  private Map<String, Object> producerConfigs() {
     Map<String, Object> props = new HashMap<>();
-
-//    ObjectMapper mapper = new ObjectMapper();
-//    mapper.registerModule(new JavaTimeModule());
-//    mapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-//
-//    JsonSerializer<Object> serializer = new JsonSerializer<>(mapper);
-
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return props;
+  }
 
-    return new DefaultKafkaProducerFactory<>(props);
+  @Bean
+  public ProducerFactory<String, ThreadHoldResponse> eventProducerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
   }
 
   @Bean
   public KafkaTemplate<String, ThreadHoldResponse> paymentCompletedEventKafkaTemplate() {
     return new KafkaTemplate<>(eventProducerFactory());
+  }
+
+  @Bean
+  public ProducerFactory<String, DropStatusChangedEvent> dropsStatusChangedEventProducerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
+  }
+
+  @Bean
+  public KafkaTemplate<String, DropStatusChangedEvent> dropsStatusChangedKafkaTemplate() {
+    return new KafkaTemplate<>(dropsStatusChangedEventProducerFactory());
   }
 }

--- a/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
@@ -7,4 +7,5 @@ public class KafkaTopics {
 
   public static final String TOPIC_QUEUE_TOKEN = "queue-token";
   public static final String TOPIC_READY_QUEUE_TOKEN = "ready-queue-token";
+  public static final String TOPIC_DROPS_STATUS_CHANGED = "drops.status.changed";
 }

--- a/src/main/java/com/example/dropshop/domain/drops/event/DropStatusChangedEvent.java
+++ b/src/main/java/com/example/dropshop/domain/drops/event/DropStatusChangedEvent.java
@@ -1,0 +1,22 @@
+package com.example.dropshop.domain.drops.event;
+
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 드랍 상태 변경 이벤트.
+ */
+@Getter
+@Builder
+public class DropStatusChangedEvent {
+
+  private final Long dropId;
+  private final Long productId;
+  private final DropsStatus fromStatus;
+  private final DropsStatus toStatus;
+  private final String cause;
+  private final LocalDateTime occurredAt;
+}
+

--- a/src/main/java/com/example/dropshop/domain/drops/producer/DropsStatusChangedEventProducer.java
+++ b/src/main/java/com/example/dropshop/domain/drops/producer/DropsStatusChangedEventProducer.java
@@ -1,0 +1,47 @@
+package com.example.dropshop.domain.drops.producer;
+
+import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_DROPS_STATUS_CHANGED;
+
+import com.example.dropshop.domain.drops.event.DropStatusChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 드랍 상태 변경 이벤트 생산자.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DropsStatusChangedEventProducer {
+
+  private final KafkaTemplate<String, DropStatusChangedEvent> dropsStatusChangedKafkaTemplate;
+
+  /**
+   * 드랍 상태 변경 이벤트를 발행한다.
+   */
+  public void send(DropStatusChangedEvent event) {
+    String key = String.valueOf(event.getDropId());
+    try {
+      dropsStatusChangedKafkaTemplate.send(TOPIC_DROPS_STATUS_CHANGED, key, event)
+          .whenComplete((result, exception) -> {
+            if (exception != null) {
+              log.warn("드랍 상태 변경 이벤트 발행 실패. dropId={}, from={}, to={}",
+                  event.getDropId(), event.getFromStatus(), event.getToStatus(), exception);
+              return;
+            }
+            log.debug("드랍 상태 변경 이벤트 발행 성공. topic={}, partition={}, offset={}, dropId={}",
+                TOPIC_DROPS_STATUS_CHANGED,
+                result.getRecordMetadata().partition(),
+                result.getRecordMetadata().offset(),
+                event.getDropId());
+          });
+    } catch (Exception e) {
+      // 상태 전이 핵심 트랜잭션은 유지하고, 이벤트 발행 실패는 로그로 추적한다.
+      log.warn("드랍 상태 변경 이벤트 발행 요청 실패. dropId={}, from={}, to={}",
+          event.getDropId(), event.getFromStatus(), event.getToStatus(), e);
+    }
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * 드랍 상태 전이 단건 처리 워커.
@@ -77,6 +79,17 @@ public class DropsStatusTransitionWorker {
         .cause("SCHEDULER")
         .occurredAt(LocalDateTime.now())
         .build();
+
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          dropsStatusChangedEventProducer.send(event);
+        }
+      });
+      return;
+    }
+
     dropsStatusChangedEventProducer.send(event);
   }
 }

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
@@ -1,8 +1,12 @@
 package com.example.dropshop.domain.drops.service;
 
 import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.event.DropStatusChangedEvent;
+import com.example.dropshop.domain.drops.producer.DropsStatusChangedEventProducer;
 import com.example.dropshop.domain.product.enums.ProductStatus;
 import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
@@ -18,6 +22,7 @@ public class DropsStatusTransitionWorker {
 
   private final DropsService dropsService;
   private final ProductDomainFacadeService productDomainFacadeService;
+  private final DropsStatusChangedEventProducer dropsStatusChangedEventProducer;
 
   /**
    * 단일 예정 드랍을 ACTIVE로 전이한다.
@@ -32,8 +37,14 @@ public class DropsStatusTransitionWorker {
       return false;
     }
 
+    DropsStatus fromStatus = drops.getStatus();
     drops.activate();
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+    publishStatusChangedEvent(
+        drops,
+        fromStatus,
+        DropsStatus.ACTIVE
+    );
     return true;
   }
 
@@ -50,9 +61,23 @@ public class DropsStatusTransitionWorker {
       return false;
     }
 
+    DropsStatus fromStatus = drops.getStatus();
     drops.finish();
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+    publishStatusChangedEvent(drops, fromStatus, DropsStatus.FINISHED);
     return true;
+  }
+
+  private void publishStatusChangedEvent(Drops drops, DropsStatus fromStatus, DropsStatus toStatus) {
+    DropStatusChangedEvent event = DropStatusChangedEvent.builder()
+        .dropId(drops.getId())
+        .productId(drops.getProduct().getId())
+        .fromStatus(fromStatus)
+        .toStatus(toStatus)
+        .cause("SCHEDULER")
+        .occurredAt(LocalDateTime.now())
+        .build();
+    dropsStatusChangedEventProducer.send(event);
   }
 }
 

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
@@ -1,0 +1,126 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.drops.event.DropStatusChangedEvent;
+import com.example.dropshop.domain.drops.producer.DropsStatusChangedEventProducer;
+import com.example.dropshop.domain.product.entity.Product;
+import com.example.dropshop.domain.product.enums.ProductStatus;
+import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DropsStatusTransitionWorkerTest {
+
+  @Mock
+  private DropsService dropsService;
+
+  @Mock
+  private ProductDomainFacadeService productDomainFacadeService;
+
+  @Mock
+  private DropsStatusChangedEventProducer dropsStatusChangedEventProducer;
+
+  @InjectMocks
+  private DropsStatusTransitionWorker worker;
+
+  @Test
+  @DisplayName("SCHEDULED 드랍을 ACTIVE로 전이하면 상태 변경 이벤트를 발행한다")
+  void transitionScheduledDrop_publishEvent() {
+    Drops drops = createDrop(1L, DropsStatus.SCHEDULED);
+    given(dropsService.findById(1L)).willReturn(drops);
+
+    boolean transitioned = worker.transitionScheduledDrop(1L);
+
+    assertThat(transitioned).isTrue();
+    verify(productDomainFacadeService).updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.ON_SALE));
+
+    ArgumentCaptor<DropStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DropStatusChangedEvent.class);
+    verify(dropsStatusChangedEventProducer).send(eventCaptor.capture());
+    DropStatusChangedEvent event = eventCaptor.getValue();
+    assertThat(event.getDropId()).isEqualTo(1L);
+    assertThat(event.getProductId()).isEqualTo(drops.getProduct().getId());
+    assertThat(event.getFromStatus()).isEqualTo(DropsStatus.SCHEDULED);
+    assertThat(event.getToStatus()).isEqualTo(DropsStatus.ACTIVE);
+    assertThat(event.getCause()).isEqualTo("SCHEDULER");
+  }
+
+  @Test
+  @DisplayName("ACTIVE 드랍을 FINISHED로 전이하면 상태 변경 이벤트를 발행한다")
+  void transitionActiveDrop_publishEvent() {
+    Drops drops = createDrop(2L, DropsStatus.ACTIVE);
+    given(dropsService.findById(2L)).willReturn(drops);
+
+    boolean transitioned = worker.transitionActiveDrop(2L);
+
+    assertThat(transitioned).isTrue();
+    verify(productDomainFacadeService).updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.OUT_OF_STOCK));
+
+    ArgumentCaptor<DropStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DropStatusChangedEvent.class);
+    verify(dropsStatusChangedEventProducer).send(eventCaptor.capture());
+    DropStatusChangedEvent event = eventCaptor.getValue();
+    assertThat(event.getDropId()).isEqualTo(2L);
+    assertThat(event.getFromStatus()).isEqualTo(DropsStatus.ACTIVE);
+    assertThat(event.getToStatus()).isEqualTo(DropsStatus.FINISHED);
+    assertThat(event.getCause()).isEqualTo("SCHEDULER");
+  }
+
+  @Test
+  @DisplayName("전이 조건에 맞지 않으면 이벤트를 발행하지 않는다")
+  void transitionScheduledDrop_notScheduled_skip() {
+    Drops drops = createDrop(3L, DropsStatus.ACTIVE);
+    given(dropsService.findById(3L)).willReturn(drops);
+
+    boolean transitioned = worker.transitionScheduledDrop(3L);
+
+    assertThat(transitioned).isFalse();
+    verify(productDomainFacadeService, never()).updateStatusByDrop(any(), any());
+    verify(dropsStatusChangedEventProducer, never()).send(any());
+  }
+
+  private Drops createDrop(Long dropId, DropsStatus status) {
+    Product product = Product.create(
+        1L,
+        "테스트 상품",
+        "TEST",
+        new BigDecimal("10000"),
+        0,
+        10,
+        "https://example.com/thumb.jpg",
+        "설명",
+        "스펙",
+        "배송",
+        "환불"
+    );
+    ReflectionTestUtils.setField(product, "id", 100L + dropId);
+
+    LocalDateTime now = LocalDateTime.now();
+    Drops drops = Drops.create(product, now.minusHours(1), now.plusHours(1), 10L, 1L, false);
+    ReflectionTestUtils.setField(drops, "id", dropId);
+
+    if (status == DropsStatus.ACTIVE) {
+      drops.activate();
+    } else if (status == DropsStatus.FINISHED) {
+      drops.finish();
+    }
+
+    return drops;
+  }
+}
+


### PR DESCRIPTION
## 📌 PR 제목
feat: drops 상태 전이 이벤트(drops.status.changed) 1단계 도입

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `drops` 상태 전이 성공 시 Kafka 이벤트를 발행하도록 1단계 도입
  - 토픽: `drops.status.changed`
- 신규 이벤트 모델 추가
  - `DropStatusChangedEvent` (`dropId`, `productId`, `fromStatus`, `toStatus`, `cause`, `occurredAt`)
- 신규 Producer 추가
  - `DropsStatusChangedEventProducer`
  - key를 `dropId`로 발행하여 동일 drop 이벤트 순서성을 확보하기 쉬운 구조로 적용
- `DropsStatusTransitionWorker` 변경
  - `SCHEDULED -> ACTIVE`, `ACTIVE -> FINISHED` 전이 성공 시 이벤트 발행
  - 기존 `Product` 상태 동기 반영(`ON_SALE`, `OUT_OF_STOCK`)은 유지
- Kafka 설정 확장
  - `KafkaProducerConfig`에 `DropStatusChangedEvent` 전용 `ProducerFactory`/`KafkaTemplate` 빈 추가
  - 토픽 상수 `TOPIC_DROPS_STATUS_CHANGED` 추가

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

- close #이슈번호

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] 단위 테스트 완료
  - `DropsStatusTransitionWorkerTest` 신규 작성
  - 상태 전이 성공 시 이벤트 발행 검증
  - 전이 조건 불충족 시 이벤트 미발행 검증
- [x] 기존 전이 테스트 회귀 확인
  - `DropsStatusTransitionServiceTest`
- [ ] Postman 테스트 완료
- [x] 예외 처리 확인 (전이 조건 미충족 분기)

---

## 💡 참고 사항
- 이번 PR은 상태 전이 후 이벤트 발행만 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 드롭 상태 변화 시 자동으로 상태 변경 이벤트를 생성·발행하도록 추가

* **Chores**
  * 이벤트 발행 인프라 및 관련 설정을 정리·재구성
  * Kafka 토픽 및 프로듀서 구성 보강

* **Tests**
  * 드롭 상태 전환 시 이벤트 생성·발행과 연관 동작을 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->