### PR TITLE
Feat/drops redis lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     runtimeOnly 'org.flywaydb:flyway-mysql'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 }
 

--- a/src/main/java/com/example/dropshop/common/config/CacheConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/CacheConfig.java
@@ -48,8 +48,9 @@ public class CacheConfig {
             BasicPolymorphicTypeValidator.builder()
               .allowIfSubTypeIsArray()
               .allowIfBaseType("java.util")
-              .allowIfBaseType("com.example.dropshop.domain")
-              .allowIfBaseType("org.springframework.data.domain")
+              .allowIfSubType("com.example.dropshop.")
+              .allowIfSubType("org.springframework.data.domain.")
+              .allowIfSubType("org.springframework.cache.support.")
                 .build(),
             ObjectMapper.DefaultTyping.NON_FINAL
         );

--- a/src/main/java/com/example/dropshop/common/config/CacheConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/CacheConfig.java
@@ -1,0 +1,123 @@
+package com.example.dropshop.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 기반 캐시 설정.
+ *
+ * <p>캐시 계층을 통해 반복 조회 요청에 대한 DB 부하를 줄이고 응답 속도를 개선한다.
+ * 캐시별 TTL 정책:
+ * <ul>
+ *   <li>{@code product:list} — 30초: 상품 목록은 드랍 상태 변경(스케줄러 30초 주기)에 따라 변경될 수 있다.</li>
+ *   <li>{@code product:detail} — 60초: 상품 상세는 목록보다 변경 빈도가 낮다.</li>
+ *   <li>{@code drop:latest} — 30초: 드랍 시작/종료 정보와 정합성을 유지한다.</li>
+ * </ul>
+ *
+ * <p><b>주의:</b> 재고 수량은 실시간 정합성이 핵심이므로 캐시 대상에서 제외한다.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+  /**
+   * 캐시 전용 ObjectMapper.
+   *
+   * <p>타입 정보를 JSON에 포함하여 올바른 역직렬화를 보장한다.
+   * {@code NON_FINAL} 범위로 한정해 불필요한 타입 노출을 최소화한다.
+   */
+  private ObjectMapper buildCacheObjectMapper() {
+    return new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
+                .build(),
+            ObjectMapper.DefaultTyping.NON_FINAL
+        );
+  }
+
+  /**
+   * 캐시 값 직렬화기.
+   *
+   * <p>Spring Data Redis 4.0에서 {@code Jackson2JsonRedisSerializer},
+   * {@code GenericJackson2JsonRedisSerializer}가 제거됨에 따라
+   * {@link RedisSerializer}를 직접 구현한다.
+   * ObjectMapper에 설정된 default typing이 JSON에 타입 메타데이터를 포함시켜
+   * 역직렬화 시 올바른 타입으로 복원한다.
+   */
+  private RedisSerializer<Object> buildValueSerializer() {
+    ObjectMapper mapper = buildCacheObjectMapper();
+    return new RedisSerializer<>() {
+      @Override
+      public byte[] serialize(Object value) throws SerializationException {
+        if (value == null) {
+          return new byte[0];
+        }
+        try {
+          return mapper.writeValueAsBytes(value);
+        } catch (IOException e) {
+          throw new SerializationException("Redis 캐시 직렬화 실패", e);
+        }
+      }
+
+      @Override
+      public Object deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null || bytes.length == 0) {
+          return null;
+        }
+        try {
+          return mapper.readValue(bytes, Object.class);
+        } catch (IOException e) {
+          throw new SerializationException("Redis 캐시 역직렬화 실패", e);
+        }
+      }
+    };
+  }
+
+  /**
+   * RedisCacheManager 빈을 등록한다.
+   */
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+    RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofSeconds(60))
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+        )
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(buildValueSerializer())
+        );
+
+    return RedisCacheManager.builder(factory)
+        .cacheDefaults(defaults)
+        .withCacheConfiguration(
+            CacheNames.PRODUCT_LIST,
+            defaults.entryTtl(Duration.ofSeconds(30))
+        )
+        .withCacheConfiguration(
+            CacheNames.PRODUCT_DETAIL,
+            defaults.entryTtl(Duration.ofSeconds(60))
+        )
+        .withCacheConfiguration(
+            CacheNames.DROP_LATEST,
+            defaults.entryTtl(Duration.ofSeconds(30))
+        )
+        .build();
+  }
+}

--- a/src/main/java/com/example/dropshop/common/config/CacheConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/CacheConfig.java
@@ -46,7 +46,8 @@ public class CacheConfig {
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .activateDefaultTyping(
             BasicPolymorphicTypeValidator.builder()
-                .allowIfSubType(Object.class)
+              .allowIfSubTypeIsArray()
+              .allowIfBaseType("com.example.dropshop.domain")
                 .build(),
             ObjectMapper.DefaultTyping.NON_FINAL
         );

--- a/src/main/java/com/example/dropshop/common/config/CacheConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/CacheConfig.java
@@ -47,7 +47,9 @@ public class CacheConfig {
         .activateDefaultTyping(
             BasicPolymorphicTypeValidator.builder()
               .allowIfSubTypeIsArray()
+              .allowIfBaseType("java.util")
               .allowIfBaseType("com.example.dropshop.domain")
+              .allowIfBaseType("org.springframework.data.domain")
                 .build(),
             ObjectMapper.DefaultTyping.NON_FINAL
         );

--- a/src/main/java/com/example/dropshop/common/config/CacheNames.java
+++ b/src/main/java/com/example/dropshop/common/config/CacheNames.java
@@ -1,0 +1,20 @@
+package com.example.dropshop.common.config;
+
+/**
+ * Redis 캐시 이름 상수.
+ */
+public final class CacheNames {
+
+  private CacheNames() {
+  }
+
+  /** 공개 상품 목록 캐시. TTL: 30초 */
+  public static final String PRODUCT_LIST = "product:list";
+
+  /** 공개 상품 상세 캐시. TTL: 60초 */
+  public static final String PRODUCT_DETAIL = "product:detail";
+
+  /** 상품별 최신 드랍 캐시. TTL: 30초 */
+  public static final String DROP_LATEST = "drop:latest";
+}
+

--- a/src/main/java/com/example/dropshop/common/config/kafka/consumer/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/consumer/KafkaConsumerConfig.java
@@ -14,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 /**
  * 카프카 소비자 설정.
@@ -31,14 +30,13 @@ public class KafkaConsumerConfig {
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ConsumerConfig.GROUP_ID_CONFIG, groupName);
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        ThreadHoldResponseKafkaDeserializer.class
+    );
     props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     return props;
-  }
-
-  private JsonDeserializer<ThreadHoldResponse> getJsonDeserializerWithThreadHoldResponse() {
-    return new JsonDeserializer<>(ThreadHoldResponse.class);
   }
 
   @Bean
@@ -46,7 +44,7 @@ public class KafkaConsumerConfig {
     return new DefaultKafkaConsumerFactory<>(
         getConsumerConfig(QUEUE_GROUP_NAME),
         new StringDeserializer(),
-        getJsonDeserializerWithThreadHoldResponse()
+        new ThreadHoldResponseKafkaDeserializer()
     );
   }
 
@@ -64,7 +62,7 @@ public class KafkaConsumerConfig {
     return new DefaultKafkaConsumerFactory<>(
         getConsumerConfig(READY_QUEUE_GROUP_NAME),
         new StringDeserializer(),
-        getJsonDeserializerWithThreadHoldResponse()
+        new ThreadHoldResponseKafkaDeserializer()
     );
   }
 

--- a/src/main/java/com/example/dropshop/common/config/kafka/consumer/ThreadHoldResponseKafkaDeserializer.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/consumer/ThreadHoldResponseKafkaDeserializer.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 
 /**
  * Kafka value deserializer for {@link ThreadHoldResponse} JSON payloads.
@@ -14,7 +15,9 @@ import org.apache.kafka.common.serialization.Deserializer;
 public class ThreadHoldResponseKafkaDeserializer implements Deserializer<ThreadHoldResponse> {
 
   private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+      new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {

--- a/src/main/java/com/example/dropshop/common/config/kafka/consumer/ThreadHoldResponseKafkaDeserializer.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/consumer/ThreadHoldResponseKafkaDeserializer.java
@@ -1,0 +1,42 @@
+package com.example.dropshop.common.config.kafka.consumer;
+
+import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * Kafka value deserializer for {@link ThreadHoldResponse} JSON payloads.
+ */
+public class ThreadHoldResponseKafkaDeserializer implements Deserializer<ThreadHoldResponse> {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    // no-op
+  }
+
+  @Override
+  public ThreadHoldResponse deserialize(String topic, byte[] data) {
+    if (data == null || data.length == 0) {
+      return null;
+    }
+
+    try {
+      return OBJECT_MAPPER.readValue(data, ThreadHoldResponse.class);
+    } catch (IOException e) {
+      throw new SerializationException("Kafka JSON 역직렬화에 실패했습니다.", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+}
+

--- a/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
@@ -1,8 +1,5 @@
 package com.example.dropshop.common.config.kafka.produce;
 
-import com.example.dropshop.domain.payment.event.PaymentStatusChangedEvent;
-import com.example.dropshop.domain.drops.event.DropStatusChangedEvent;
-import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -14,7 +11,6 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 
 /**
  * 카프카 생산자 설정.
@@ -27,46 +23,20 @@ public class KafkaProducerConfig {
   private String bootstrapServers;
 
   @Bean
-  public ProducerFactory<String, ThreadHoldResponse> eventProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerProperties());
+  public ProducerFactory<String, Object> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
   }
-
-  @Bean
-  public ProducerFactory<String, PaymentStatusChangedEvent> paymentEventProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerProperties());
-  }
-
-  private Map<String, Object> producerProperties() {
-    Map<String, Object> props = new HashMap<>();
 
   private Map<String, Object> producerConfigs() {
     Map<String, Object> props = new HashMap<>();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectJsonKafkaSerializer.class);
     return props;
   }
 
-    return props;
   @Bean
-  public ProducerFactory<String, ThreadHoldResponse> eventProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerConfigs());
-  }
-
-  @Bean
-  public KafkaTemplate<String, ThreadHoldResponse> paymentCompletedEventKafkaTemplate() {
-    return new KafkaTemplate<>(eventProducerFactory());
-  }
-
-  @Bean
-  public KafkaTemplate<String, PaymentStatusChangedEvent> paymentEventKafkaTemplate() {
-    return new KafkaTemplate<>(paymentEventProducerFactory());
-  public ProducerFactory<String, DropStatusChangedEvent> dropsStatusChangedEventProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerConfigs());
-  }
-
-  @Bean
-  public KafkaTemplate<String, DropStatusChangedEvent> dropsStatusChangedKafkaTemplate() {
-    return new KafkaTemplate<>(dropsStatusChangedEventProducerFactory());
+  public KafkaTemplate<String, Object> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
   }
 }

--- a/src/main/java/com/example/dropshop/common/config/kafka/produce/ObjectJsonKafkaSerializer.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/produce/ObjectJsonKafkaSerializer.java
@@ -1,0 +1,42 @@
+package com.example.dropshop.common.config.kafka.produce;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * Kafka value serializer for JSON payloads.
+ */
+public class ObjectJsonKafkaSerializer implements Serializer<Object> {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    // no-op
+  }
+
+  @Override
+  public byte[] serialize(String topic, Object data) {
+    if (data == null) {
+      return null;
+    }
+
+    try {
+      return OBJECT_MAPPER.writeValueAsBytes(data);
+    } catch (JsonProcessingException e) {
+      throw new SerializationException("Kafka JSON 직렬화에 실패했습니다.", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+}
+
+

--- a/src/main/java/com/example/dropshop/common/lock/LockKeys.java
+++ b/src/main/java/com/example/dropshop/common/lock/LockKeys.java
@@ -19,4 +19,8 @@ public final class LockKeys {
   public static String refund(Long refundId) {
     return "lock:refund:" + refundId;
   }
+
+  public static String dropStock(Long dropId) {
+    return "lock:drop:stock:" + dropId;
+  }
 }

--- a/src/main/java/com/example/dropshop/domain/drops/producer/DropsStatusChangedEventProducer.java
+++ b/src/main/java/com/example/dropshop/domain/drops/producer/DropsStatusChangedEventProducer.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class DropsStatusChangedEventProducer {
 
-  private final KafkaTemplate<String, DropStatusChangedEvent> dropsStatusChangedKafkaTemplate;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
 
   /**
    * 드랍 상태 변경 이벤트를 발행한다.
@@ -24,7 +24,7 @@ public class DropsStatusChangedEventProducer {
   public void send(DropStatusChangedEvent event) {
     String key = String.valueOf(event.getDropId());
     try {
-      dropsStatusChangedKafkaTemplate.send(TOPIC_DROPS_STATUS_CHANGED, key, event)
+      kafkaTemplate.send(TOPIC_DROPS_STATUS_CHANGED, key, event)
           .whenComplete((result, exception) -> {
             if (exception != null) {
               log.warn("드랍 상태 변경 이벤트 발행 실패. dropId={}, from={}, to={}",

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsFacadeService.java
@@ -1,6 +1,9 @@
 package com.example.dropshop.domain.drops.service;
 
+import com.example.dropshop.common.config.CacheNames;
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.lock.LockKeys;
+import com.example.dropshop.common.lock.RedisLockService;
 import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
 import com.example.dropshop.domain.drops.dto.request.DropUpdateRequest;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
@@ -19,9 +22,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * 드랍 도메인 파사드 서비스.
@@ -35,10 +42,17 @@ public class DropsFacadeService {
   private final ProductDomainFacadeService productDomainFacadeService;
   private final OrderHistoryQueryService orderHistoryQueryService;
   private final DropsRepository dropsRepository;
+  private final RedisLockService redisLockService;
+  private final DropsStockPreemptionService dropsStockPreemptionService;
 
   /**
    * 판매자 드랍을 생성한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#request.productId"),
+      @CacheEvict(value = CacheNames.DROP_LATEST, key = "#request.productId")
+  })
   @Transactional
   public DropResponse createSellerDrop(
       Long sellerId,
@@ -59,6 +73,11 @@ public class DropsFacadeService {
   /**
    * 판매자 드랍을 수정한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, allEntries = true),
+      @CacheEvict(value = CacheNames.DROP_LATEST, allEntries = true)
+  })
   @Transactional
   public DropResponse updateSellerDrop(
       Long dropId,
@@ -80,6 +99,11 @@ public class DropsFacadeService {
   /**
    * 판매자 드랍을 삭제한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, allEntries = true),
+      @CacheEvict(value = CacheNames.DROP_LATEST, allEntries = true)
+  })
   @Transactional
   public void deleteSellerDrop(
       Long dropId,
@@ -107,6 +131,11 @@ public class DropsFacadeService {
   /**
    * 판매자 드랍을 강제 종료한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, allEntries = true),
+      @CacheEvict(value = CacheNames.DROP_LATEST, allEntries = true)
+  })
   @Transactional
   public DropResponse stopSellerDrop(
       Long dropId,
@@ -168,22 +197,36 @@ public class DropsFacadeService {
 
   /**
    * 주문 취소/결제 실패 시 드랍 재고를 복원한다.
+   *
+   * <p>분산락으로 동시 복원 요청을 직렬화해 {@code @Version} 기반 낙관적 락 충돌을 최소화한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, allEntries = true),
+      @CacheEvict(value = CacheNames.DROP_LATEST, allEntries = true)
+  })
   @Transactional
   public void restoreStockForOrder(Long dropId, int quantity) {
-    Drops drops = dropsService.findById(dropId);
-    drops.restoreRemainStock(quantity);
+    redisLockService.executeWithLock(LockKeys.dropStock(dropId), () -> {
+      Drops drops = dropsService.findById(dropId);
+      drops.restoreRemainStock(quantity);
 
-    try {
-      if (drops.isFinished()
-          && drops.getRemainStock() > 0L
-          && LocalDateTime.now().isBefore(drops.getEndAt())) {
-        drops.activate();
-        productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+      registerAfterCommit(
+          () -> dropsStockPreemptionService.increaseStockAfterRestore(dropId, quantity)
+      );
+
+      try {
+        if (drops.isFinished()
+            && drops.getRemainStock() > 0L
+            && LocalDateTime.now().isBefore(drops.getEndAt())) {
+          drops.activate();
+          productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+        }
+      } catch (OptimisticLockingFailureException e) {
+        log.info("드랍 ID={} 재활성화가 동시성 충돌로 스킵되었습니다.", dropId, e);
       }
-    } catch (OptimisticLockingFailureException e) {
-      log.info("드랍 ID={} 재활성화가 동시성 충돌로 스킵되었습니다.", dropId, e);
-    }
+      return null;
+    });
   }
 
   /**
@@ -200,21 +243,63 @@ public class DropsFacadeService {
       throw new DropsException(ErrorCode.INVALID_DROP_ORDER_QUANTITY);
     }
 
-    Drops drops = dropsService.findById(dropId);
-
-    if (!drops.isActive()) {
-      throw new DropsException(ErrorCode.DROP_ORDER_NOT_ALLOWED);
-    }
-    if (!drops.getProduct().getId().equals(productId)) {
-      throw new DropsException(ErrorCode.DROP_PRODUCT_MISMATCH);
+    boolean reserved = dropsStockPreemptionService.tryReserve(dropId, quantity);
+    if (!reserved) {
+      throw new DropsException(ErrorCode.INVALID_DROP_REMAIN_STOCK);
     }
 
-    drops.decrementRemainStock(quantity);
-    if (drops.getRemainStock() <= 0L) {
-      drops.finish();
-      productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
+    // Redis 선점 성공 이후에는 예외 발생 여부와 무관하게 롤백 보상을 등록한다.
+    registerRollbackCompensation(dropId, quantity);
+
+    return redisLockService.executeWithLock(LockKeys.dropStock(dropId), () -> {
+      Drops found = dropsService.findById(dropId);
+
+      if (!found.isActive()) {
+        throw new DropsException(ErrorCode.DROP_ORDER_NOT_ALLOWED);
+      }
+      if (!found.getProduct().getId().equals(productId)) {
+        throw new DropsException(ErrorCode.DROP_PRODUCT_MISMATCH);
+      }
+
+      found.decrementRemainStock(quantity);
+      if (found.getRemainStock() <= 0L) {
+        found.finish();
+        productDomainFacadeService.updateStatusByDrop(
+            found.getProduct(),
+            ProductStatus.OUT_OF_STOCK
+        );
+      }
+      return found;
+    });
+  }
+
+  private void registerRollbackCompensation(Long dropId, int quantity) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      return;
     }
-    return drops;
+
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCompletion(int status) {
+        if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
+          dropsStockPreemptionService.compensateReservedStock(dropId, quantity);
+        }
+      }
+    });
+  }
+
+  private void registerAfterCommit(Runnable action) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          action.run();
+        }
+      });
+      return;
+    }
+
+    action.run();
   }
 }
 

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
@@ -24,6 +24,7 @@ public class DropsStatusTransitionWorker {
 
   private final DropsService dropsService;
   private final ProductDomainFacadeService productDomainFacadeService;
+  private final DropsStockPreemptionService dropsStockPreemptionService;
   private final DropsStatusChangedEventProducer dropsStatusChangedEventProducer;
 
   /**
@@ -42,6 +43,7 @@ public class DropsStatusTransitionWorker {
     DropsStatus fromStatus = drops.getStatus();
     drops.activate();
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
+    registerAfterCommit(() -> dropsStockPreemptionService.preloadStockKey(dropId));
     publishStatusChangedEvent(
         drops,
         fromStatus,
@@ -68,6 +70,20 @@ public class DropsStatusTransitionWorker {
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
     publishStatusChangedEvent(drops, fromStatus, DropsStatus.FINISHED);
     return true;
+  }
+
+  private void registerAfterCommit(Runnable action) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          action.run();
+        }
+      });
+      return;
+    }
+
+    action.run();
   }
 
   private void publishStatusChangedEvent(Drops drops, DropsStatus fromStatus, DropsStatus toStatus) {

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorker.java
@@ -40,7 +40,7 @@ public class DropsStatusTransitionWorker {
       return false;
     }
 
-    DropsStatus fromStatus = drops.getStatus();
+    final DropsStatus fromStatus = drops.getStatus();
     drops.activate();
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.ON_SALE);
     registerAfterCommit(() -> dropsStockPreemptionService.preloadStockKey(dropId));
@@ -65,7 +65,7 @@ public class DropsStatusTransitionWorker {
       return false;
     }
 
-    DropsStatus fromStatus = drops.getStatus();
+    final DropsStatus fromStatus = drops.getStatus();
     drops.finish();
     productDomainFacadeService.updateStatusByDrop(drops.getProduct(), ProductStatus.OUT_OF_STOCK);
     publishStatusChangedEvent(drops, fromStatus, DropsStatus.FINISHED);
@@ -86,7 +86,11 @@ public class DropsStatusTransitionWorker {
     action.run();
   }
 
-  private void publishStatusChangedEvent(Drops drops, DropsStatus fromStatus, DropsStatus toStatus) {
+  private void publishStatusChangedEvent(
+      Drops drops,
+      DropsStatus fromStatus,
+      DropsStatus toStatus
+  ) {
     DropStatusChangedEvent event = DropStatusChangedEvent.builder()
         .dropId(drops.getId())
         .productId(drops.getProduct().getId())

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
@@ -56,6 +56,9 @@ public class DropsStockPreemptionService {
 
   /**
    * 주문 수량만큼 재고를 선점한다.
+   *
+   * <p>주문 핫패스에서는 KEY_MISSING 재초기화를 수행하지 않고 fail-close 처리한다.
+   * 재초기화는 ACTIVE 전환 선적재/복구 후 반영 경로에서만 수행해 기준 재고를 단일화한다.
    */
   public boolean tryReserve(Long dropId, int quantity) {
     validatePositiveQuantity(quantity);
@@ -69,13 +72,13 @@ public class DropsStockPreemptionService {
     if (reserveResult == RESERVE_RESULT_INSUFFICIENT) {
       return false;
     }
-    if (reserveResult != RESERVE_RESULT_KEY_MISSING) {
+
+    if (reserveResult == RESERVE_RESULT_KEY_MISSING) {
+      log.warn("Redis 재고 키 없음으로 주문 선점을 fail-close 처리합니다. dropId={}", dropId);
       return false;
     }
 
-    initializeStockKeyIfAbsent(dropId);
-    Long retryResult = executeReserve(dropId, quantity);
-    return retryResult != null && retryResult >= 0L;
+    return false;
   }
 
   /**

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
@@ -1,0 +1,156 @@
+package com.example.dropshop.domain.drops.service;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis 기반 드랍 재고 선점 서비스.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DropsStockPreemptionService {
+
+  private static final long RESERVE_RESULT_INSUFFICIENT = -1L;
+  private static final long RESERVE_RESULT_KEY_MISSING = -2L;
+
+  private static final DefaultRedisScript<Long> RESERVE_SCRIPT;
+  private static final DefaultRedisScript<Long> INCREASE_IF_EXISTS_SCRIPT;
+
+  static {
+    RESERVE_SCRIPT = new DefaultRedisScript<>();
+    RESERVE_SCRIPT.setScriptText(
+        "local current = redis.call('get', KEYS[1])\n"
+            + "if not current then\n"
+            + "  return -2\n"
+            + "end\n"
+            + "current = tonumber(current)\n"
+            + "local quantity = tonumber(ARGV[1])\n"
+            + "if current < quantity then\n"
+            + "  return -1\n"
+            + "end\n"
+            + "return redis.call('decrby', KEYS[1], quantity)"
+    );
+    RESERVE_SCRIPT.setResultType(Long.class);
+
+    INCREASE_IF_EXISTS_SCRIPT = new DefaultRedisScript<>();
+    INCREASE_IF_EXISTS_SCRIPT.setScriptText(
+        "if redis.call('exists', KEYS[1]) == 1 then\n"
+            + "  redis.call('incrby', KEYS[1], ARGV[1])\n"
+            + "  return 1\n"
+            + "end\n"
+            + "return 0"
+    );
+    INCREASE_IF_EXISTS_SCRIPT.setResultType(Long.class);
+  }
+
+  private final StringRedisTemplate stringRedisTemplate;
+  private final DropsService dropsService;
+
+  /**
+   * 주문 수량만큼 재고를 선점한다.
+   */
+  public boolean tryReserve(Long dropId, int quantity) {
+    Long reserveResult = executeReserve(dropId, quantity);
+    if (reserveResult == null) {
+      return false;
+    }
+    if (reserveResult >= 0L) {
+      return true;
+    }
+    if (reserveResult == RESERVE_RESULT_INSUFFICIENT) {
+      return false;
+    }
+    if (reserveResult != RESERVE_RESULT_KEY_MISSING) {
+      return false;
+    }
+
+    initializeStockKeyIfAbsent(dropId);
+    Long retryResult = executeReserve(dropId, quantity);
+    return retryResult != null && retryResult >= 0L;
+  }
+
+  /**
+   * 주문 선점 후 트랜잭션 롤백 시 Redis 선점량을 보상한다.
+   *
+   * <p>키가 없으면 덮어쓰지 않고 다음 요청의 lazy init에 맡긴다.
+   */
+  public void compensateReservedStock(Long dropId, int quantity) {
+    Long increased = executeIncreaseIfExists(dropId, quantity);
+    if (!Long.valueOf(1L).equals(increased)) {
+      log.debug("Redis 보상 스킵: 키가 없거나 증가 실패. dropId={}, quantity={}", dropId, quantity);
+    }
+  }
+
+  /**
+   * 주문 취소/실패 복구가 커밋된 뒤 Redis 재고를 반영한다.
+   *
+   * <p>키가 존재하면 INCRBY를 수행하고, 키가 없으면 DB 스냅샷으로 안전하게 선적재한다.
+   */
+  public void increaseStockAfterRestore(Long dropId, int quantity) {
+    Long increased = executeIncreaseIfExists(dropId, quantity);
+    if (Long.valueOf(1L).equals(increased)) {
+      return;
+    }
+
+    initializeStockKeyIfAbsent(dropId);
+  }
+
+  /**
+   * 드랍 ACTIVE 전환 시 Redis 재고 키를 미리 적재한다.
+   */
+  public void preloadStockKey(Long dropId) {
+    initializeStockKeyIfAbsent(dropId);
+  }
+
+  private Long executeReserve(Long dropId, int quantity) {
+    return stringRedisTemplate.execute(
+        RESERVE_SCRIPT,
+        Collections.singletonList(stockKey(dropId)),
+        String.valueOf(quantity)
+    );
+  }
+
+  private Long executeIncreaseIfExists(Long dropId, int quantity) {
+    return stringRedisTemplate.execute(
+        INCREASE_IF_EXISTS_SCRIPT,
+        Collections.singletonList(stockKey(dropId)),
+        String.valueOf(quantity)
+    );
+  }
+
+  private void initializeStockKeyIfAbsent(Long dropId) {
+    Drops drops = dropsService.findById(dropId);
+    Duration ttl = calculateKeyTtl(drops);
+    if (ttl.isZero() || ttl.isNegative()) {
+      log.debug("Redis 재고 키 미적재: 이미 종료된 드랍입니다. dropId={}", dropId);
+      return;
+    }
+
+    stringRedisTemplate.opsForValue().setIfAbsent(
+        stockKey(dropId),
+        String.valueOf(drops.getRemainStock()),
+        ttl
+    );
+  }
+
+  private Duration calculateKeyTtl(Drops drops) {
+    LocalDateTime now = LocalDateTime.now();
+    if (!drops.getEndAt().isAfter(now)) {
+      return Duration.ZERO;
+    }
+    return Duration.between(now, drops.getEndAt()).plusSeconds(1);
+  }
+
+  private String stockKey(Long dropId) {
+    return "stock:drop:" + dropId;
+  }
+}
+

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionService.java
@@ -58,6 +58,7 @@ public class DropsStockPreemptionService {
    * 주문 수량만큼 재고를 선점한다.
    */
   public boolean tryReserve(Long dropId, int quantity) {
+    validatePositiveQuantity(quantity);
     Long reserveResult = executeReserve(dropId, quantity);
     if (reserveResult == null) {
       return false;
@@ -83,6 +84,7 @@ public class DropsStockPreemptionService {
    * <p>키가 없으면 덮어쓰지 않고 다음 요청의 lazy init에 맡긴다.
    */
   public void compensateReservedStock(Long dropId, int quantity) {
+    validatePositiveQuantity(quantity);
     Long increased = executeIncreaseIfExists(dropId, quantity);
     if (!Long.valueOf(1L).equals(increased)) {
       log.debug("Redis 보상 스킵: 키가 없거나 증가 실패. dropId={}, quantity={}", dropId, quantity);
@@ -95,6 +97,7 @@ public class DropsStockPreemptionService {
    * <p>키가 존재하면 INCRBY를 수행하고, 키가 없으면 DB 스냅샷으로 안전하게 선적재한다.
    */
   public void increaseStockAfterRestore(Long dropId, int quantity) {
+    validatePositiveQuantity(quantity);
     Long increased = executeIncreaseIfExists(dropId, quantity);
     if (Long.valueOf(1L).equals(increased)) {
       return;
@@ -151,6 +154,12 @@ public class DropsStockPreemptionService {
 
   private String stockKey(Long dropId) {
     return "stock:drop:" + dropId;
+  }
+
+  private void validatePositiveQuantity(int quantity) {
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("quantity must be greater than 0");
+    }
   }
 }
 

--- a/src/main/java/com/example/dropshop/domain/payment/producer/PaymentEventProducer.java
+++ b/src/main/java/com/example/dropshop/domain/payment/producer/PaymentEventProducer.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PaymentEventProducer {
 
-  private final KafkaTemplate<String, PaymentStatusChangedEvent> paymentEventKafkaTemplate;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
 
   /**
    * 결제 상태에 맞는 토픽으로 이벤트를 전송한다.
@@ -24,7 +24,7 @@ public class PaymentEventProducer {
    * @param event 결제 상태 변경 이벤트
    */
   public void send(PaymentStatusChangedEvent event) {
-    paymentEventKafkaTemplate.send(resolveTopic(event), event.eventKey(), event);
+    kafkaTemplate.send(resolveTopic(event), event.eventKey(), event);
   }
 
   private String resolveTopic(PaymentStatusChangedEvent event) {

--- a/src/main/java/com/example/dropshop/domain/product/entity/Product.java
+++ b/src/main/java/com/example/dropshop/domain/product/entity/Product.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -118,6 +119,13 @@ public class Product extends BaseEntity {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)
   private ProductStatus status;
+
+  /**
+   * 낙관적 락 버전 필드.
+   * 이미지/상태/가격 동시 수정 시 lost update(덮어쓰기)를 방지한다.
+   */
+  @Version
+  private Long version;
 
   /**
    * 상품 이미지 목록 (최대 {@value MAX_IMAGE_COUNT}개).

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductCommandService.java
@@ -1,5 +1,6 @@
 package com.example.dropshop.domain.product.service;
 
+import com.example.dropshop.common.config.CacheNames;
 import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.domain.product.common.service.ProductPolicyService;
 import com.example.dropshop.domain.product.dto.request.ProductCreateRequest;
@@ -18,6 +19,8 @@ import com.example.dropshop.domain.product.validator.ProductValidator;
 import java.math.BigDecimal;
 import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -82,6 +85,10 @@ public class ProductCommandService {
   /**
    * 판매자 상품 정보를 수정한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
+  })
   @Transactional
   public ProductCreateResponse updateSellerProduct(
       Long productId,
@@ -134,6 +141,10 @@ public class ProductCommandService {
   /**
    * 판매자 상품 상태를 수동 변경한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
+  })
   @Transactional
   public ProductCreateResponse changeSellerProductStatus(
       Long productId,
@@ -157,6 +168,10 @@ public class ProductCommandService {
   /**
    * 판매자 상품을 삭제한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
+  })
   @Transactional
   public void deleteSellerProduct(
       Long productId,
@@ -179,6 +194,10 @@ public class ProductCommandService {
   /**
    * 판매자 상품 이미지를 추가한다.
    */
+  @Caching(evict = {
+      @CacheEvict(value = CacheNames.PRODUCT_LIST, allEntries = true),
+      @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
+  })
   @Transactional
   public ProductImageResponse createSellerProductImage(
       Long productId,
@@ -210,6 +229,7 @@ public class ProductCommandService {
   /**
    * 판매자 상품 이미지를 수정한다.
    */
+  @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
   @Transactional
   public ProductImageResponse updateSellerProductImage(
       Long productId,
@@ -243,6 +263,7 @@ public class ProductCommandService {
   /**
    * 판매자 상품 이미지를 삭제한다.
    */
+  @CacheEvict(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
   @Transactional
   public void deleteSellerProductImage(
       Long productId,

--- a/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/product/service/ProductQueryService.java
@@ -1,5 +1,6 @@
 package com.example.dropshop.domain.product.service;
 
+import com.example.dropshop.common.config.CacheNames;
 import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.service.DropsFacadeService;
@@ -21,6 +22,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -49,7 +51,14 @@ public class ProductQueryService {
 
   /**
    * 공개 상품 목록을 조회한다.
+   *
+   * <p>동일 파라미터(status, sort, page, size)로 반복 요청 시 Redis 캐시에서 반환한다.
+   * TTL: 30초 / 상품·드랍 변경 시 {@code product:list} 캐시 전체 무효화.
    */
+  @Cacheable(
+      value = CacheNames.PRODUCT_LIST,
+      key = "'status=' + #status + ':sort=' + #sort + ':page=' + #pageable.pageNumber + ':size=' + #pageable.pageSize"
+  )
   @Transactional(readOnly = true)
   public Page<ProductListItemResponse> findPublicProducts(
       String status,
@@ -73,7 +82,11 @@ public class ProductQueryService {
 
   /**
    * 공개 상품 상세를 조회한다.
+   *
+   * <p>상품 ID 기준으로 Redis 캐시에서 반환한다.
+   * TTL: 60초 / 상품 수정·이미지 변경·드랍 변경 시 해당 상품 캐시 무효화.
    */
+  @Cacheable(value = CacheNames.PRODUCT_DETAIL, key = "#productId")
   @Transactional(readOnly = true)
   public ProductDetailResponse findPublicProductDetail(Long productId) {
     Product product = productRepository.findDetailById(productId)

--- a/src/main/java/com/example/dropshop/domain/queue/producer/QueueTokenProducer.java
+++ b/src/main/java/com/example/dropshop/domain/queue/producer/QueueTokenProducer.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class QueueTokenProducer {
-  private final KafkaTemplate<String, ThreadHoldResponse> queueTokenCompletedEventKafkaTemplate;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
 
   /**
    * send.
    * @param threadHoldResponse dto.
    */
   public void send(ThreadHoldResponse threadHoldResponse) {
-    queueTokenCompletedEventKafkaTemplate.send(TOPIC_QUEUE_TOKEN, threadHoldResponse);
+    kafkaTemplate.send(TOPIC_QUEUE_TOKEN, threadHoldResponse);
   }
 }

--- a/src/main/java/com/example/dropshop/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/example/dropshop/domain/queue/service/QueueScheduler.java
@@ -34,7 +34,7 @@ public class QueueScheduler {
   private final QueueRepository queueRepository;
   private final QueueTokenRepository queueTokenRepository;
   private final StringRedisTemplate stringRedisTemplate;
-  private final KafkaTemplate<String, ThreadHoldResponse> kafkaTemplate;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
   private final ObjectMapper objectMapper;
 
   @Scheduled(fixedRate = 200) // 0.2 polling

--- a/src/main/resources/db/migration/V11__add_product_version_column.sql
+++ b/src/main/resources/db/migration/V11__add_product_version_column.sql
@@ -1,0 +1,7 @@
+-- products 테이블에 낙관적 락용 version 컬럼 추가
+-- 목적: 이미지/상태/가격 동시 수정 시 lost update 방지
+-- 기존 데이터는 DEFAULT 0으로 초기화
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0
+        COMMENT '낙관적 락 버전 (JPA @Version)';
+

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsFacadeServiceTest.java
@@ -3,12 +3,15 @@ package com.example.dropshop.domain.drops.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.example.dropshop.common.exception.ErrorCode;
+import com.example.dropshop.common.lock.RedisLockService;
 import com.example.dropshop.domain.drops.dto.request.DropCreateRequest;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.entity.Drops;
@@ -21,12 +24,15 @@ import com.example.dropshop.domain.product.service.ProductDomainFacadeService;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,8 +50,23 @@ class DropsFacadeServiceTest {
   @Mock
   private OrderHistoryQueryService orderHistoryQueryService;
 
+  @Mock
+  private RedisLockService redisLockService;
+
+  @Mock
+  private DropsStockPreemptionService dropsStockPreemptionService;
+
   @InjectMocks
   private DropsFacadeService dropsFacadeService;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(redisLockService.executeWithLock(anyString(), any()))
+        .thenAnswer(invocation -> {
+          RedisLockService.LockCallback<?> callback = invocation.getArgument(1);
+          return callback.doInLock();
+        });
+  }
 
   @Test
   @DisplayName("판매자 드랍 생성 성공 시 상품 상태를 READY로 변경한다")
@@ -107,12 +128,54 @@ class DropsFacadeServiceTest {
     Drops drops = createActiveDrop(product, now);
     ReflectionTestUtils.setField(drops, "remainStock", 5L);
 
+    given(dropsStockPreemptionService.tryReserve(DEFAULT_DROP_ID, 1)).willReturn(true);
     given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
 
     Drops result = dropsFacadeService.reserveStockForOrder(DEFAULT_DROP_ID, 1L, 1);
 
     assertThat(result.getRemainStock()).isEqualTo(4L);
+    verify(dropsStockPreemptionService, never()).compensateReservedStock(DEFAULT_DROP_ID, 1);
     verify(productDomainFacadeService, never()).updateStatusByDrop(any(Product.class), any(ProductStatus.class));
+  }
+
+  @Test
+  @DisplayName("Redis 선점에 실패하면 재고 차감 없이 예외를 던진다")
+  void reserveStockForOrder_redisReserveFail_throwsException() {
+    given(dropsStockPreemptionService.tryReserve(DEFAULT_DROP_ID, 1)).willReturn(false);
+
+    assertThatThrownBy(() -> dropsFacadeService.reserveStockForOrder(DEFAULT_DROP_ID, 1L, 1))
+        .isInstanceOf(DropsException.class)
+        .hasMessage(ErrorCode.INVALID_DROP_REMAIN_STOCK.getMessage());
+
+    verify(dropsService, never()).findById(DEFAULT_DROP_ID);
+    verify(dropsStockPreemptionService, never()).compensateReservedStock(DEFAULT_DROP_ID, 1);
+  }
+
+  @Test
+  @DisplayName("선점 후 예외가 발생하면 롤백 훅에서 Redis 보상을 수행한다")
+  void reserveStockForOrder_productMismatch_compensateRedisOnRollbackHook() {
+    LocalDateTime now = LocalDateTime.now();
+    Product product = createProduct(1L);
+    Drops drops = createActiveDrop(product, now);
+
+    given(dropsStockPreemptionService.tryReserve(DEFAULT_DROP_ID, 1)).willReturn(true);
+    given(dropsService.findById(DEFAULT_DROP_ID)).willReturn(drops);
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      assertThatThrownBy(() -> dropsFacadeService.reserveStockForOrder(DEFAULT_DROP_ID, 999L, 1))
+          .isInstanceOf(DropsException.class)
+          .hasMessage(ErrorCode.DROP_PRODUCT_MISMATCH.getMessage());
+
+      assertThat(TransactionSynchronizationManager.getSynchronizations()).hasSize(1);
+      for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+        synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+      }
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    verify(dropsStockPreemptionService).compensateReservedStock(DEFAULT_DROP_ID, 1);
   }
 
   @Test

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
@@ -35,12 +35,17 @@ class DropsStatusTransitionWorkerTest {
   private ProductDomainFacadeService productDomainFacadeService;
 
   @Mock
+  private DropsStockPreemptionService dropsStockPreemptionService;
   private DropsStatusChangedEventProducer dropsStatusChangedEventProducer;
 
   @InjectMocks
   private DropsStatusTransitionWorker worker;
 
   @Test
+  @DisplayName("SCHEDULED -> ACTIVE 전이 성공 시 Redis 재고 키를 선적재한다")
+  void transitionScheduledDrop_preloadRedisKey() {
+    Drops scheduledDrop = createDrop(1L, DropsStatus.SCHEDULED);
+    given(dropsService.findById(1L)).willReturn(scheduledDrop);
   @DisplayName("SCHEDULED 드랍을 ACTIVE로 전이하면 상태 변경 이벤트를 발행한다")
   void transitionScheduledDrop_publishEvent() {
     Drops drops = createDrop(1L, DropsStatus.SCHEDULED);
@@ -49,6 +54,10 @@ class DropsStatusTransitionWorkerTest {
     boolean transitioned = worker.transitionScheduledDrop(1L);
 
     assertThat(transitioned).isTrue();
+    assertThat(scheduledDrop.isActive()).isTrue();
+    verify(productDomainFacadeService)
+        .updateStatusByDrop(scheduledDrop.getProduct(), ProductStatus.ON_SALE);
+    verify(dropsStockPreemptionService).preloadStockKey(1L);
     verify(productDomainFacadeService).updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.ON_SALE));
 
     ArgumentCaptor<DropStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DropStatusChangedEvent.class);
@@ -82,14 +91,21 @@ class DropsStatusTransitionWorkerTest {
   }
 
   @Test
+  @DisplayName("이미 ACTIVE/FINISHED인 드랍은 전이하지 않고 Redis 선적재도 하지 않는다")
+  void transitionScheduledDrop_skipWhenNotScheduled() {
+    Drops activeDrop = createDrop(2L, DropsStatus.ACTIVE);
+    given(dropsService.findById(2L)).willReturn(activeDrop);
   @DisplayName("전이 조건에 맞지 않으면 이벤트를 발행하지 않는다")
   void transitionScheduledDrop_notScheduled_skip() {
     Drops drops = createDrop(3L, DropsStatus.ACTIVE);
     given(dropsService.findById(3L)).willReturn(drops);
 
+    boolean transitioned = worker.transitionScheduledDrop(2L);
     boolean transitioned = worker.transitionScheduledDrop(3L);
 
     assertThat(transitioned).isFalse();
+    verify(productDomainFacadeService, never()).updateStatusByDrop(activeDrop.getProduct(), ProductStatus.ON_SALE);
+    verify(dropsStockPreemptionService, never()).preloadStockKey(2L);
     verify(productDomainFacadeService, never()).updateStatusByDrop(any(), any());
     verify(dropsStatusChangedEventProducer, never()).send(any());
   }
@@ -99,20 +115,36 @@ class DropsStatusTransitionWorkerTest {
         1L,
         "테스트 상품",
         "TEST",
+        new BigDecimal("100000"),
         new BigDecimal("10000"),
         0,
         10,
+        100,
         "https://example.com/thumb.jpg",
+        "상품 설명",
+        "상품 상세",
+        "배송 안내",
+        "환불 정책"
         "설명",
         "스펙",
         "배송",
         "환불"
     );
+    ReflectionTestUtils.setField(product, "id", 101L);
     ReflectionTestUtils.setField(product, "id", 100L + dropId);
 
+    Drops drops = Drops.create(
+        product,
+        LocalDateTime.now().minusHours(1),
+        LocalDateTime.now().plusHours(3),
+        10L,
+        1L,
+        false
+    );
     LocalDateTime now = LocalDateTime.now();
     Drops drops = Drops.create(product, now.minusHours(1), now.plusHours(1), 10L, 1L, false);
     ReflectionTestUtils.setField(drops, "id", dropId);
+    ReflectionTestUtils.setField(drops, "status", status);
 
     if (status == DropsStatus.ACTIVE) {
       drops.activate();
@@ -123,4 +155,5 @@ class DropsStatusTransitionWorkerTest {
     return drops;
   }
 }
+
 

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStatusTransitionWorkerTest.java
@@ -36,32 +36,31 @@ class DropsStatusTransitionWorkerTest {
 
   @Mock
   private DropsStockPreemptionService dropsStockPreemptionService;
+
+  @Mock
   private DropsStatusChangedEventProducer dropsStatusChangedEventProducer;
 
   @InjectMocks
   private DropsStatusTransitionWorker worker;
 
   @Test
-  @DisplayName("SCHEDULED -> ACTIVE 전이 성공 시 Redis 재고 키를 선적재한다")
-  void transitionScheduledDrop_preloadRedisKey() {
-    Drops scheduledDrop = createDrop(1L, DropsStatus.SCHEDULED);
-    given(dropsService.findById(1L)).willReturn(scheduledDrop);
-  @DisplayName("SCHEDULED 드랍을 ACTIVE로 전이하면 상태 변경 이벤트를 발행한다")
-  void transitionScheduledDrop_publishEvent() {
+  @DisplayName("SCHEDULED 드랍을 ACTIVE로 전이하면 상태 이벤트를 발행하고 Redis 키를 선적재한다")
+  void transitionScheduledDrop_publishEventAndPreloadKey() {
     Drops drops = createDrop(1L, DropsStatus.SCHEDULED);
     given(dropsService.findById(1L)).willReturn(drops);
 
     boolean transitioned = worker.transitionScheduledDrop(1L);
 
     assertThat(transitioned).isTrue();
-    assertThat(scheduledDrop.isActive()).isTrue();
+    assertThat(drops.isActive()).isTrue();
     verify(productDomainFacadeService)
-        .updateStatusByDrop(scheduledDrop.getProduct(), ProductStatus.ON_SALE);
+        .updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.ON_SALE));
     verify(dropsStockPreemptionService).preloadStockKey(1L);
-    verify(productDomainFacadeService).updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.ON_SALE));
 
-    ArgumentCaptor<DropStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DropStatusChangedEvent.class);
+    ArgumentCaptor<DropStatusChangedEvent> eventCaptor =
+        ArgumentCaptor.forClass(DropStatusChangedEvent.class);
     verify(dropsStatusChangedEventProducer).send(eventCaptor.capture());
+
     DropStatusChangedEvent event = eventCaptor.getValue();
     assertThat(event.getDropId()).isEqualTo(1L);
     assertThat(event.getProductId()).isEqualTo(drops.getProduct().getId());
@@ -79,10 +78,13 @@ class DropsStatusTransitionWorkerTest {
     boolean transitioned = worker.transitionActiveDrop(2L);
 
     assertThat(transitioned).isTrue();
-    verify(productDomainFacadeService).updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.OUT_OF_STOCK));
+    verify(productDomainFacadeService)
+        .updateStatusByDrop(eq(drops.getProduct()), eq(ProductStatus.OUT_OF_STOCK));
 
-    ArgumentCaptor<DropStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DropStatusChangedEvent.class);
+    ArgumentCaptor<DropStatusChangedEvent> eventCaptor =
+        ArgumentCaptor.forClass(DropStatusChangedEvent.class);
     verify(dropsStatusChangedEventProducer).send(eventCaptor.capture());
+
     DropStatusChangedEvent event = eventCaptor.getValue();
     assertThat(event.getDropId()).isEqualTo(2L);
     assertThat(event.getFromStatus()).isEqualTo(DropsStatus.ACTIVE);
@@ -91,21 +93,28 @@ class DropsStatusTransitionWorkerTest {
   }
 
   @Test
-  @DisplayName("이미 ACTIVE/FINISHED인 드랍은 전이하지 않고 Redis 선적재도 하지 않는다")
-  void transitionScheduledDrop_skipWhenNotScheduled() {
-    Drops activeDrop = createDrop(2L, DropsStatus.ACTIVE);
-    given(dropsService.findById(2L)).willReturn(activeDrop);
-  @DisplayName("전이 조건에 맞지 않으면 이벤트를 발행하지 않는다")
+  @DisplayName("전이 조건에 맞지 않으면 전이/이벤트/선적재를 모두 수행하지 않는다")
   void transitionScheduledDrop_notScheduled_skip() {
-    Drops drops = createDrop(3L, DropsStatus.ACTIVE);
-    given(dropsService.findById(3L)).willReturn(drops);
+    Drops activeDrop = createDrop(3L, DropsStatus.ACTIVE);
+    given(dropsService.findById(3L)).willReturn(activeDrop);
 
-    boolean transitioned = worker.transitionScheduledDrop(2L);
     boolean transitioned = worker.transitionScheduledDrop(3L);
 
     assertThat(transitioned).isFalse();
-    verify(productDomainFacadeService, never()).updateStatusByDrop(activeDrop.getProduct(), ProductStatus.ON_SALE);
-    verify(dropsStockPreemptionService, never()).preloadStockKey(2L);
+    verify(productDomainFacadeService, never()).updateStatusByDrop(any(), any());
+    verify(dropsStockPreemptionService, never()).preloadStockKey(3L);
+    verify(dropsStatusChangedEventProducer, never()).send(any());
+  }
+
+  @Test
+  @DisplayName("ACTIVE가 아닌 드랍은 FINISHED 전이와 이벤트 발행을 수행하지 않는다")
+  void transitionActiveDrop_notActive_skip() {
+    Drops scheduledDrop = createDrop(4L, DropsStatus.SCHEDULED);
+    given(dropsService.findById(4L)).willReturn(scheduledDrop);
+
+    boolean transitioned = worker.transitionActiveDrop(4L);
+
+    assertThat(transitioned).isFalse();
     verify(productDomainFacadeService, never()).updateStatusByDrop(any(), any());
     verify(dropsStatusChangedEventProducer, never()).send(any());
   }
@@ -116,8 +125,6 @@ class DropsStatusTransitionWorkerTest {
         "테스트 상품",
         "TEST",
         new BigDecimal("100000"),
-        new BigDecimal("10000"),
-        0,
         10,
         100,
         "https://example.com/thumb.jpg",
@@ -125,32 +132,13 @@ class DropsStatusTransitionWorkerTest {
         "상품 상세",
         "배송 안내",
         "환불 정책"
-        "설명",
-        "스펙",
-        "배송",
-        "환불"
     );
-    ReflectionTestUtils.setField(product, "id", 101L);
     ReflectionTestUtils.setField(product, "id", 100L + dropId);
 
-    Drops drops = Drops.create(
-        product,
-        LocalDateTime.now().minusHours(1),
-        LocalDateTime.now().plusHours(3),
-        10L,
-        1L,
-        false
-    );
     LocalDateTime now = LocalDateTime.now();
     Drops drops = Drops.create(product, now.minusHours(1), now.plusHours(1), 10L, 1L, false);
     ReflectionTestUtils.setField(drops, "id", dropId);
     ReflectionTestUtils.setField(drops, "status", status);
-
-    if (status == DropsStatus.ACTIVE) {
-      drops.activate();
-    } else if (status == DropsStatus.FINISHED) {
-      drops.finish();
-    }
 
     return drops;
   }

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionServiceTest.java
@@ -1,0 +1,245 @@
+package com.example.dropshop.domain.drops.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.dropshop.domain.drops.entity.Drops;
+import com.example.dropshop.domain.drops.enums.DropsStatus;
+import com.example.dropshop.domain.product.entity.Product;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * DropsStockPreemptionService 단위 테스트.
+ *
+ * <p>Redis Lua 스크립트 결과값에 따른 재고 선점/보상 분기를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked") // RedisScript<T> 제네릭 Mockito any() 경고 억제
+class DropsStockPreemptionServiceTest {
+
+  private static final Long DROP_ID = 1L;
+  private static final Long REMAIN_STOCK = 10L;
+
+  @Mock
+  private StringRedisTemplate stringRedisTemplate;
+
+  @Mock
+  private DropsService dropsService;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @InjectMocks
+  private DropsStockPreemptionService dropsStockPreemptionService;
+
+  private Drops drops;
+
+  @BeforeEach
+  void setUp() {
+    Product product = Product.create(
+        1L, "한정판 스니커즈", "SHOES",
+        new BigDecimal("250000"), 10, 100,
+        "https://cdn.example.com/thumb.jpg",
+        "<p>설명</p>", "사이즈: 255", "배송 안내", "환불 정책"
+    );
+    ReflectionTestUtils.setField(product, "id", 1L);
+
+    drops = Drops.create(
+        product,
+        LocalDateTime.now().minusHours(1),
+        LocalDateTime.now().plusHours(1),
+        REMAIN_STOCK,
+        1L,
+        true
+    );
+    ReflectionTestUtils.setField(drops, "id", DROP_ID);
+    ReflectionTestUtils.setField(drops, "status", DropsStatus.ACTIVE);
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // tryReserve: 재고 선점 성공
+  // ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Redis 키가 존재하고 재고가 충분하면 선점에 성공한다")
+  void tryReserve_success_whenStockSufficient() {
+    // Lua 스크립트 결과: 선점 후 남은 재고 = 9
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(9L);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
+
+    assertThat(result).isTrue();
+    verify(dropsService, never()).findById(DROP_ID);
+  }
+
+  @Test
+  @DisplayName("선점 후 남은 재고가 0이어도 선점에 성공한다")
+  void tryReserve_success_whenStockBecomesZero() {
+    // 재고가 딱 1개 남아있어 선점 후 0이 되는 경우
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(0L);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
+
+    assertThat(result).isTrue();
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // tryReserve: 재고 부족으로 실패
+  // ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Redis 재고가 부족하면 선점에 실패한다 (Lua 결과 -1)")
+  void tryReserve_fail_whenStockInsufficient() {
+    // Lua 스크립트 결과: 재고 부족 = -1
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(-1L);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 5);
+
+    assertThat(result).isFalse();
+    verify(dropsService, never()).findById(DROP_ID);
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // tryReserve: 키 미존재 → DB 초기화 후 재시도
+  // ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Redis 키가 없으면 DB에서 재고를 초기화한 뒤 재시도해 성공한다")
+  void tryReserve_keyMissing_initFromDb_thenSuccess() {
+    given(dropsService.findById(DROP_ID)).willReturn(drops);
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+
+    // 1차: 키 없음(-2), 2차: 재시도 성공(9)
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(-2L)
+        .willReturn(9L);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
+
+    assertThat(result).isTrue();
+    // DB 초기화 호출 확인
+    verify(dropsService).findById(DROP_ID);
+    verify(valueOperations).setIfAbsent(
+        eq("stock:drop:" + DROP_ID),
+        eq(String.valueOf(REMAIN_STOCK)),
+        any(Duration.class)
+    );
+  }
+
+  @Test
+  @DisplayName("Redis 키 초기화 후 재시도에서도 재고가 부족하면 실패한다")
+  void tryReserve_keyMissing_initFromDb_thenFail() {
+    given(dropsService.findById(DROP_ID)).willReturn(drops);
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+
+    // 1차: 키 없음(-2), 2차: 재고 부족(-1)
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(-2L)
+        .willReturn(-1L);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 100);
+
+    assertThat(result).isFalse();
+    verify(dropsService).findById(DROP_ID);
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // tryReserve: Redis execute null 반환
+  // ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Redis execute가 null을 반환하면 선점에 실패한다")
+  void tryReserve_fail_whenRedisReturnsNull() {
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(null);
+
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
+
+    assertThat(result).isFalse();
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // increaseStock: 보상/복구 재고 증가
+  // ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("Redis 키가 존재할 때 compensateReservedStock은 INCRBY만 호출한다")
+  void compensateReservedStock_success_whenKeyExists() {
+    // INCREASE_IF_EXISTS_SCRIPT 결과: 1 (키 존재 + 증가 성공)
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(1L);
+
+    dropsStockPreemptionService.compensateReservedStock(DROP_ID, 1);
+
+    // DB 초기화 없이 Redis만 update
+    verify(dropsService, never()).findById(DROP_ID);
+  }
+
+  @Test
+  @DisplayName("Redis 키가 없을 때 compensateReservedStock은 DB를 조회하지 않는다")
+  void compensateReservedStock_skip_whenKeyMissing() {
+    // INCREASE_IF_EXISTS_SCRIPT 결과: 0 (키 없음)
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(0L);
+    dropsStockPreemptionService.compensateReservedStock(DROP_ID, 1);
+
+    verify(dropsService, never()).findById(DROP_ID);
+  }
+
+  @Test
+  @DisplayName("Redis 키가 없을 때 increaseStockAfterRestore는 DB 기준으로 키를 적재한다")
+  void increaseStockAfterRestore_reinitialize_whenKeyMissing() {
+    given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+        .willReturn(0L);
+    given(dropsService.findById(DROP_ID)).willReturn(drops);
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+    dropsStockPreemptionService.increaseStockAfterRestore(DROP_ID, 1);
+
+    verify(dropsService).findById(DROP_ID);
+    verify(valueOperations).setIfAbsent(
+        eq("stock:drop:" + DROP_ID),
+        eq(String.valueOf(REMAIN_STOCK)),
+        any(Duration.class)
+    );
+  }
+
+  @Test
+  @DisplayName("ACTIVE 전환 선적재 시 preloadStockKey는 SET NX를 사용한다")
+  void preloadStockKey_usesSetIfAbsent() {
+    given(dropsService.findById(DROP_ID)).willReturn(drops);
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+    dropsStockPreemptionService.preloadStockKey(DROP_ID);
+
+    verify(valueOperations).setIfAbsent(
+        eq("stock:drop:" + DROP_ID),
+        eq(String.valueOf(REMAIN_STOCK)),
+        any(Duration.class)
+    );
+  }
+}

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsStockPreemptionServiceTest.java
@@ -122,47 +122,31 @@ class DropsStockPreemptionServiceTest {
   }
 
   // ─────────────────────────────────────────────────────────
-  // tryReserve: 키 미존재 → DB 초기화 후 재시도
+  // tryReserve: 키 미존재 → fail-close
   // ─────────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("Redis 키가 없으면 DB에서 재고를 초기화한 뒤 재시도해 성공한다")
-  void tryReserve_keyMissing_initFromDb_thenSuccess() {
-    given(dropsService.findById(DROP_ID)).willReturn(drops);
-    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
-
-    // 1차: 키 없음(-2), 2차: 재시도 성공(9)
+  @DisplayName("Redis 키가 없으면 주문 선점은 fail-close 처리한다")
+  void tryReserve_keyMissing_failClose() {
     given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
-        .willReturn(-2L)
-        .willReturn(9L);
+        .willReturn(-2L);
 
     boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
 
-    assertThat(result).isTrue();
-    // DB 초기화 호출 확인
-    verify(dropsService).findById(DROP_ID);
-    verify(valueOperations).setIfAbsent(
-        eq("stock:drop:" + DROP_ID),
-        eq(String.valueOf(REMAIN_STOCK)),
-        any(Duration.class)
-    );
+    assertThat(result).isFalse();
+    verify(dropsService, never()).findById(DROP_ID);
   }
 
   @Test
-  @DisplayName("Redis 키 초기화 후 재시도에서도 재고가 부족하면 실패한다")
-  void tryReserve_keyMissing_initFromDb_thenFail() {
-    given(dropsService.findById(DROP_ID)).willReturn(drops);
-    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
-
-    // 1차: 키 없음(-2), 2차: 재고 부족(-1)
+  @DisplayName("정의되지 않은 음수 결과는 선점 실패로 처리한다")
+  void tryReserve_fail_whenUnexpectedNegativeResult() {
     given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
-        .willReturn(-2L)
-        .willReturn(-1L);
+        .willReturn(-3L);
 
-    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 100);
+    boolean result = dropsStockPreemptionService.tryReserve(DROP_ID, 1);
 
     assertThat(result).isFalse();
-    verify(dropsService).findById(DROP_ID);
+    verify(dropsService, never()).findById(DROP_ID);
   }
 
   // ─────────────────────────────────────────────────────────

--- a/src/test/java/com/example/dropshop/domain/refund/service/RefundCompletionWorkerTest.java
+++ b/src/test/java/com/example/dropshop/domain/refund/service/RefundCompletionWorkerTest.java
@@ -82,21 +82,21 @@ class RefundCompletionWorkerTest {
         refundCompletionWorker.prepareRefundCompletion(1L, "test@test.com");
 
     assertThat(refund.getStatus()).isEqualTo(RefundStatus.PROCESSING);
-    assertThat(command.portOneTransactionId()).isEqualTo("tx-123");
+    assertThat(command.portOnePaymentId()).isEqualTo("payment-test-123");
     assertThat(command.refundReason()).isEqualTo("단순 변심");
   }
 
   @Test
-  @DisplayName("환불 완료 준비 시 portOneTransactionId가 없으면 예외가 발생한다")
-  void prepareRefundCompletion_withoutPortOneTransactionId_throwsException() {
-    Payment paymentWithoutPortOneTransactionId =
+  @DisplayName("환불 완료 준비 시 portOnePaymentId가 없으면 예외가 발생한다")
+  void prepareRefundCompletion_withoutPortOnePaymentId_throwsException() {
+    Payment paymentWithoutPortOnePaymentId =
         Payment.prepare(1L, "payment-test-123", PaymentMethod.CARD, new BigDecimal("79000"));
-    ReflectionTestUtils.setField(paymentWithoutPortOneTransactionId, "id", 1L);
-    paymentWithoutPortOneTransactionId.complete("tx-123");
-    ReflectionTestUtils.setField(paymentWithoutPortOneTransactionId, "portOneTransactionId", " ");
+    ReflectionTestUtils.setField(paymentWithoutPortOnePaymentId, "id", 1L);
+    paymentWithoutPortOnePaymentId.complete("tx-123");
+    ReflectionTestUtils.setField(paymentWithoutPortOnePaymentId, "merchantPaymentId", " ");
 
     given(refundRepository.findById(1L)).willReturn(Optional.of(refund));
-    given(paymentRepository.findById(1L)).willReturn(Optional.of(paymentWithoutPortOneTransactionId));
+    given(paymentRepository.findById(1L)).willReturn(Optional.of(paymentWithoutPortOnePaymentId));
 
     assertThatThrownBy(() -> refundCompletionWorker.prepareRefundCompletion(1L, "test@test.com"))
         .isInstanceOf(PaymentException.class)


### PR DESCRIPTION
## 📌 PR 제목
feat: Redis 기반 드랍 재고 동시성 제어 도입 및 Kafka 직렬화 설정 개선

---

## ✨ 변경 사항
이번 PR에서는 드랍 재고 처리의 동시성 제어를 강화하고, Spring Kafka 4.0+ 호환성 리스크를 줄이기 위한 직렬화/생산자/소비자 설정 정리를 진행했습니다.

### 변경 배경
#### 1. Redis 기반 재고 동시성 제어 도입
기존 드랍 재고 차감은 낙관적 락 중심 구조였기 때문에 한정판 드랍 오픈처럼 충돌이 집중되는 상황에서 비효율이 발생할 수 있었습니다.  
이를 보완하기 위해 **Redis DECR 기반 선점 + 분산락 + DB 안전망(@Version)** 구조로 재고 처리 경로를 개선했습니다.

#### 2. Spring Kafka 4.0+ 호환성 리스크 제거
Spring Kafka의 `JsonSerializer` / `JsonDeserializer`는 4.0+ 환경에서 제거 예정 리스크가 있어, producer/consumer 모두 커스텀 serializer/deserializer 기반으로 정리했습니다.

---

### 주요 변경사항

#### Drops / Redis 동시성 제어
- `DropsStockPreemptionService` 신규/보완
  - Redis Lua 스크립트 기반 재고 선점 처리
  - Redis 키 초기화 로직을 `SET NX` 기반으로 변경
  - `drop endAt` 기준 TTL 적용
  - `compensateReservedStock()` / `increaseStockAfterRestore()` 역할 분리
- `DropsFacadeService`
  - `reserveStockForOrder()`에서 Redis 선점 후 롤백 보상 등록
  - 즉시 보상 제거, `afterCompletion(ROLLBACK)` 보상으로 일원화
  - `restoreStockForOrder()`는 커밋 후 Redis 복원 반영
- `LockKeys`
  - `lock:drop:stock:{dropId}` 키 추가
- `DropsStatusTransitionWorker`
  - SCHEDULED → ACTIVE 전이 후 Redis 재고 키 선적재
  - 상태 변경 이벤트를 afterCommit 시점에 발행하도록 유지/정리

#### Kafka 설정 개선
- `ObjectJsonKafkaSerializer` 신규 작성
  - Jackson 기반 JSON 직렬화
  - `JavaTimeModule` 포함
  - `ObjectMapper`를 static final로 공유
- `ThreadHoldResponseKafkaDeserializer` 신규 작성
  - consumer 측 커스텀 JSON 역직렬화기 추가
- `KafkaProducerConfig`
  - `ProducerFactory`를 `<String, Object>` 단일 빈으로 통합
  - `KafkaTemplate`도 `<String, Object>` 단일 빈으로 정리
  - `typedProducerFactory()` 제거
- `KafkaConsumerConfig`
  - Spring Kafka `JsonDeserializer` 의존 제거
  - `ThreadHoldResponseKafkaDeserializer` 기반으로 변경

#### 테스트 / 리베이스 복구
- 리베이스 중 깨진 `KafkaProducerConfig` 및 관련 테스트 복구
- `DropsStatusTransitionWorkerTest` 재구성
- `RefundCompletionWorkerTest`는 변경된 command 필드명에 맞게 수정

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #이슈번호

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] Redis 재고 선점/보상 관련 테스트 확인
- [x] Drops 상태 전이 테스트 확인
- [x] Kafka 설정 변경 후 컴파일 확인
- [x] 리베이스 후 깨진 테스트 복구 및 재실행 확인

실행한 테스트:
- `DropsFacadeServiceTest`
- `DropsStockPreemptionServiceTest`
- `DropsStatusTransitionWorkerTest`
- `RefundCompletionWorkerTest`

##💡 참고 사항
- 팀원 코드 영향 (리뷰 필수)
- 아래 파일들은 KafkaTemplate 타입 또는 Redis 재고 처리 흐름 변경으로 인해 수정되었습니다. 기능 동작은 동일하거나 의도된 개선 방향이지만, 빈 주입 방식 / 재고 보상 흐름 / 상태 전이 시점이 바뀌었으므로 리뷰 시 확인 부탁드립니다.

| 파일 | 변경 내용 |
|------|-----------|
| `PaymentEventProducer` | `KafkaTemplate<String, PaymentStatusChangedEvent>` → `KafkaTemplate<String, Object>` |
| `QueueTokenProducer` | `KafkaTemplate<String, ThreadHoldResponse>` → `KafkaTemplate<String, Object>` |
| `QueueScheduler` | `KafkaTemplate<String, ThreadHoldResponse>` → `KafkaTemplate<String, Object>` |
| `DropsStatusChangedEventProducer` | `KafkaTemplate<String, DropStatusChangedEvent>` → `KafkaTemplate<String, Object>` |
| `DropsFacadeService` | Redis 선점 후 보상 로직을 롤백 훅으로 일원화 |
| `DropsStockPreemptionService` | Redis 키 초기화/TTL/보상/복원 로직 분리 |
| `DropsStatusTransitionWorker` | ACTIVE 전환 시 Redis 키 선적재, `final` 추가, 메서드 파라미터 포맷팅 정리 |
| `KafkaProducerConfig` | `ProducerFactory`/`KafkaTemplate` 단일 빈 구조로 변경 |
| `KafkaConsumerConfig` | 커스텀 deserializer 기반으로 변경 |

### 추가 참고
- 이번 PR은 기능 추가 + 인프라 설정 정리가 함께 포함되어 있습니다.
- Redis 분산락/재고 선점 구조는 한정판 드랍 오픈 시점의 충돌 집중 문제 완화가 목적입니다.
- Kafka 설정 변경은 Spring Kafka 4.0+ 제거 예정 API 의존 축소가 목적입니다.
- 이벤트 전송 토픽/키/페이로드 자체는 기존 의도를 유지합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * Redis 기반 조회 캐시(목록/상세) 도입 및 항목별 TTL로 응답 성능 향상
  * 상품·드롭 생성·수정·삭제 시 캐시 자동 무효화로 일관성 개선
  * Redis 기반 재고 선점·보상 로직 및 분산 락 적용으로 재고 안정성 강화
  * Kafka 직렬화·발행 구조 통합으로 메시지 발행 유연성 향상
  * 낙관적 잠금(버전) 도입으로 동시성 제어 강화
* **테스트**
  * 캐시·재고 선점·보상·상태전이 관련 단위 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->