### PR TITLE
feat: 결제/주문 이벤트 Kafka 발행 추가

### DIFF
--- a/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
@@ -1,5 +1,7 @@
 package com.example.dropshop.common.config.kafka.produce;
 
+import com.example.dropshop.domain.order.event.OrderStatusChangedEvent;
+import com.example.dropshop.domain.order.event.StockRestoreEvent;
 import com.example.dropshop.domain.payment.event.PaymentStatusChangedEvent;
 import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
 import java.util.HashMap;
@@ -35,6 +37,16 @@ public class KafkaProducerConfig {
     return new DefaultKafkaProducerFactory<>(producerProperties());
   }
 
+  @Bean
+  public ProducerFactory<String, OrderStatusChangedEvent> orderEventProducerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerProperties());
+  }
+
+  @Bean
+  public ProducerFactory<String, StockRestoreEvent> orderStockRestoreProducerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerProperties());
+  }
+
   private Map<String, Object> producerProperties() {
     Map<String, Object> props = new HashMap<>();
 
@@ -53,5 +65,15 @@ public class KafkaProducerConfig {
   @Bean
   public KafkaTemplate<String, PaymentStatusChangedEvent> paymentEventKafkaTemplate() {
     return new KafkaTemplate<>(paymentEventProducerFactory());
+  }
+
+  @Bean
+  public KafkaTemplate<String, OrderStatusChangedEvent> orderEventKafkaTemplate() {
+    return new KafkaTemplate<>(orderEventProducerFactory());
+  }
+
+  @Bean
+  public KafkaTemplate<String, StockRestoreEvent> orderStockRestoreKafkaTemplate() {
+    return new KafkaTemplate<>(orderStockRestoreProducerFactory());
   }
 }

--- a/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/kafka/produce/KafkaProducerConfig.java
@@ -33,12 +33,12 @@ public class KafkaProducerConfig {
 
   @Bean
   public ProducerFactory<String, OrderStatusChangedEvent> orderEventProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerProperties());
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
   }
 
   @Bean
   public ProducerFactory<String, StockRestoreEvent> orderStockRestoreProducerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerProperties());
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
   }
 
   private Map<String, Object> producerConfigs() {

--- a/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
@@ -9,4 +9,8 @@ public class KafkaTopics {
   public static final String TOPIC_READY_QUEUE_TOKEN = "ready-queue-token";
   public static final String TOPIC_PAYMENT_COMPLETED = "payment.completed";
   public static final String TOPIC_PAYMENT_FAILED = "payment.failed";
+  public static final String TOPIC_ORDER_PAID = "order.paid";
+  public static final String TOPIC_ORDER_CANCELLED = "order.cancelled";
+  public static final String TOPIC_ORDER_REFUNDED = "order.refunded";
+  public static final String TOPIC_ORDER_STOCK_RESTORED = "order.stock-restored";
 }

--- a/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
+++ b/src/main/java/com/example/dropshop/common/constant/kafka/topic/KafkaTopics.java
@@ -5,6 +5,9 @@ package com.example.dropshop.common.constant.kafka.topic;
  */
 public class KafkaTopics {
 
+  public static final String TOPIC_USER_LOGIN = "user-login";
+  public static final String TOPIC_USER_SIGNUP = "user-signup";
+  public static final String TOPIC_SELLER_APPLY = "seller-apply";
   public static final String TOPIC_QUEUE_TOKEN = "queue-token";
   public static final String TOPIC_READY_QUEUE_TOKEN = "ready-queue-token";
   public static final String TOPIC_PAYMENT_COMPLETED = "payment.completed";

--- a/src/main/java/com/example/dropshop/common/initializer/DataInitializer.java
+++ b/src/main/java/com/example/dropshop/common/initializer/DataInitializer.java
@@ -1,116 +1,116 @@
-package com.example.dropshop.common.initializer;
-
-import com.example.dropshop.domain.drops.entity.Drops;
-import com.example.dropshop.domain.drops.repository.DropsRepository;
-import com.example.dropshop.domain.product.entity.Product;
-import com.example.dropshop.domain.product.repository.ProductRepository;
-import com.example.dropshop.domain.queue.entity.Queue;
-import com.example.dropshop.domain.queue.repository.QueueRepository;
-import com.example.dropshop.domain.queue.repository.QueueTokenRepository;
-import com.example.dropshop.domain.queue.service.QueueService;
-import com.example.dropshop.domain.user.entity.User;
-import com.example.dropshop.domain.user.repository.UserRepository;
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Component;
-
-@Component
-@RequiredArgsConstructor
-public class DataInitializer implements CommandLineRunner {
-
-  private final ProductRepository productRepository;
-  private final DropsRepository dropsRepository;
-  private final QueueRepository queueRepository;
-  private final QueueTokenRepository queueTokenRepository;
-  private final UserRepository userRepository;
-  private final QueueService queueService;
-  private final PasswordEncoder passwordEncoder;
-
-  @Override
-  public void run(String... args) throws Exception {
-    Product product = Product.create(
-        1L,
-        "임시 상품 이름",
-        "임시 카테고리",
-        new BigDecimal("10000"),
-        80,
-        100,
-        "thumbnailUrl",
-        "description",
-        "specification",
-        "deliveryInfo",
-        "refundPolicy"
-    );
-
-    productRepository.save(product);
-
-    Drops drops = Drops.create(
-        product,
-        LocalDateTime.now(),
-        LocalDateTime.now().plusHours(5),
-        100L,
-        1L,
-        true
-    );
-
-    drops.activate();
-
-    dropsRepository.save(drops);
-
-    for (int i = 1; i <= 100; i++){
-      User user = User.signup(
-          i + "@email.com",
-          passwordEncoder.encode("Abc12345678!"),
-          "nickname" + i
-      );
-
-      userRepository.save(user);
-    }
-
-    ExecutorService executor = Executors.newFixedThreadPool(100);
-
-    for (int i = 1; i <= 100; i++) {
-      int userId = i;
-
-      executor.submit(() -> {
-        queueService.decideQueue(1L, (long) userId, userId + "@email.com");
-      });
-    }
-
-    executor.shutdown();
-
-
-//    ExecutorService executor = Executors.newFixedThreadPool(100);
+//package com.example.dropshop.common.initializer;
 //
-//    CountDownLatch latch = new CountDownLatch(1);
+//import com.example.dropshop.domain.drops.entity.Drops;
+//import com.example.dropshop.domain.drops.repository.DropsRepository;
+//import com.example.dropshop.domain.product.entity.Product;
+//import com.example.dropshop.domain.product.repository.ProductRepository;
+//import com.example.dropshop.domain.queue.entity.Queue;
+//import com.example.dropshop.domain.queue.repository.QueueRepository;
+//import com.example.dropshop.domain.queue.repository.QueueTokenRepository;
+//import com.example.dropshop.domain.queue.service.QueueService;
+//import com.example.dropshop.domain.user.entity.User;
+//import com.example.dropshop.domain.user.repository.UserRepository;
+//import java.math.BigDecimal;
+//import java.time.LocalDateTime;
+//import java.util.concurrent.CountDownLatch;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.security.crypto.password.PasswordEncoder;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class DataInitializer implements CommandLineRunner {
+//
+//  private final ProductRepository productRepository;
+//  private final DropsRepository dropsRepository;
+//  private final QueueRepository queueRepository;
+//  private final QueueTokenRepository queueTokenRepository;
+//  private final UserRepository userRepository;
+//  private final QueueService queueService;
+//  private final PasswordEncoder passwordEncoder;
+//
+//  @Override
+//  public void run(String... args) throws Exception {
+//    Product product = Product.create(
+//        1L,
+//        "임시 상품 이름",
+//        "임시 카테고리",
+//        new BigDecimal("10000"),
+//        80,
+//        100,
+//        "thumbnailUrl",
+//        "description",
+//        "specification",
+//        "deliveryInfo",
+//        "refundPolicy"
+//    );
+//
+//    productRepository.save(product);
+//
+//    Drops drops = Drops.create(
+//        product,
+//        LocalDateTime.now(),
+//        LocalDateTime.now().plusHours(5),
+//        100L,
+//        1L,
+//        true
+//    );
+//
+//    drops.activate();
+//
+//    dropsRepository.save(drops);
+//
+//    for (int i = 1; i <= 100; i++){
+//      User user = User.signup(
+//          i + "@email.com",
+//          passwordEncoder.encode("Abc12345678!"),
+//          "nickname" + i
+//      );
+//
+//      userRepository.save(user);
+//    }
+//
+//    ExecutorService executor = Executors.newFixedThreadPool(100);
 //
 //    for (int i = 1; i <= 100; i++) {
 //      int userId = i;
 //
 //      executor.submit(() -> {
-//        try {
-//          latch.await();
-//          queueService.decideQueue(1L, (long) userId);
-//        } catch (InterruptedException e) {
-//          e.printStackTrace();
-//        }
+//        queueService.decideQueue(1L, (long) userId, userId + "@email.com");
 //      });
 //    }
 //
-//    latch.countDown();
-//
 //    executor.shutdown();
-
-//    for (int i = 1; i <= 100; i++){
-//      queueService.decideQueue(1L, (long)1L);
-////      Queue queue = new Queue((long)i, 1L);
-////      queueRepository.save(queue);
-//    }
-  }
-}
+//
+//
+////    ExecutorService executor = Executors.newFixedThreadPool(100);
+////
+////    CountDownLatch latch = new CountDownLatch(1);
+////
+////    for (int i = 1; i <= 100; i++) {
+////      int userId = i;
+////
+////      executor.submit(() -> {
+////        try {
+////          latch.await();
+////          queueService.decideQueue(1L, (long) userId);
+////        } catch (InterruptedException e) {
+////          e.printStackTrace();
+////        }
+////      });
+////    }
+////
+////    latch.countDown();
+////
+////    executor.shutdown();
+//
+////    for (int i = 1; i <= 100; i++){
+////      queueService.decideQueue(1L, (long)1L);
+//////      Queue queue = new Queue((long)i, 1L);
+//////      queueRepository.save(queue);
+////    }
+//  }
+//}

--- a/src/main/java/com/example/dropshop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dropshop/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.example.dropshop.common.kafka.producer.EventKafkaProducer;
 import com.example.dropshop.domain.auth.dto.request.LoginRequest;
 import com.example.dropshop.domain.auth.dto.response.TokenResponse;
 import com.example.dropshop.domain.auth.entity.RefreshToken;
+import com.example.dropshop.domain.auth.event.UserLoginEvent;
 import com.example.dropshop.domain.auth.exception.AuthException;
 import com.example.dropshop.domain.auth.repository.RefreshTokenRepository;
 import com.example.dropshop.domain.auth.service.TokenBlacklistService;

--- a/src/main/java/com/example/dropshop/domain/order/event/OrderKafkaEventListener.java
+++ b/src/main/java/com/example/dropshop/domain/order/event/OrderKafkaEventListener.java
@@ -1,0 +1,37 @@
+package com.example.dropshop.domain.order.event;
+
+import com.example.dropshop.domain.order.producer.OrderEventProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 주문 도메인 이벤트를 커밋 이후 Kafka로 전달한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class OrderKafkaEventListener {
+
+  private final OrderEventProducer orderEventProducer;
+
+  /**
+   * 주문 상태 변경 이벤트를 커밋 이후 전송한다.
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(OrderStatusChangedEvent event) {
+    orderEventProducer.sendStatusChanged(event);
+  }
+
+  /**
+   * 주문 재고 복원 이벤트를 커밋 이후 전송한다.
+   */
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(StockRestoreEvent event) {
+    if (event.getOrderId() != null) {
+      orderEventProducer.sendStockRestored(event);
+    }
+  }
+}

--- a/src/main/java/com/example/dropshop/domain/order/event/OrderStatusChangedEvent.java
+++ b/src/main/java/com/example/dropshop/domain/order/event/OrderStatusChangedEvent.java
@@ -1,0 +1,47 @@
+package com.example.dropshop.domain.order.event;
+
+import com.example.dropshop.domain.order.entity.Order;
+import com.example.dropshop.domain.order.enums.OrderStatus;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+/**
+ * 주문 상태 변경 이벤트.
+ */
+@Getter
+public class OrderStatusChangedEvent {
+
+  private final Long orderId;
+  private final Long userId;
+  private final Long dropId;
+  private final String orderNumber;
+  private final OrderStatus orderStatus;
+  private final BigDecimal totalAmount;
+  private final String source;
+  private final String occurredAt;
+
+  /**
+   * 주문 상태 변경 이벤트를 생성한다.
+   *
+   * @param order 주문 엔티티
+   * @param source 이벤트 발생 출처
+   */
+  public OrderStatusChangedEvent(Order order, String source) {
+    this.orderId = order.getId();
+    this.userId = order.getUserId();
+    this.dropId = order.getDropId();
+    this.orderNumber = order.getOrderNumber();
+    this.orderStatus = order.getStatus();
+    this.totalAmount = order.getTotalAmount();
+    this.source = source;
+    this.occurredAt = LocalDateTime.now().toString();
+  }
+
+  /**
+   * 파티셔닝용 메시지 키를 반환한다.
+   */
+  public String eventKey() {
+    return String.valueOf(orderId);
+  }
+}

--- a/src/main/java/com/example/dropshop/domain/order/event/StockRestoreEvent.java
+++ b/src/main/java/com/example/dropshop/domain/order/event/StockRestoreEvent.java
@@ -1,15 +1,51 @@
 package com.example.dropshop.domain.order.event;
 
+import com.example.dropshop.domain.order.enums.OrderStatus;
+import java.time.LocalDateTime;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * 재고 복원 이벤트.
  */
 @Getter
-@RequiredArgsConstructor
 public class StockRestoreEvent {
 
+  private final Long orderId;
   private final Long dropId;
   private final int quantity;
+  private final OrderStatus orderStatus;
+  private final String source;
+  private final String occurredAt;
+
+  /**
+   * 내부 재고 복원 이벤트를 생성한다.
+   */
+  public StockRestoreEvent(Long dropId, int quantity) {
+    this(null, dropId, quantity, null, null);
+  }
+
+  /**
+   * Kafka 전파용 재고 복원 이벤트를 생성한다.
+   */
+  public StockRestoreEvent(
+      Long orderId,
+      Long dropId,
+      int quantity,
+      OrderStatus orderStatus,
+      String source
+  ) {
+    this.orderId = orderId;
+    this.dropId = dropId;
+    this.quantity = quantity;
+    this.orderStatus = orderStatus;
+    this.source = source;
+    this.occurredAt = LocalDateTime.now().toString();
+  }
+
+  /**
+   * 파티셔닝용 메시지 키를 반환한다.
+   */
+  public String eventKey() {
+    return String.valueOf(orderId == null ? dropId : orderId);
+  }
 }

--- a/src/main/java/com/example/dropshop/domain/order/producer/OrderEventProducer.java
+++ b/src/main/java/com/example/dropshop/domain/order/producer/OrderEventProducer.java
@@ -1,0 +1,48 @@
+package com.example.dropshop.domain.order.producer;
+
+import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_ORDER_CANCELLED;
+import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_ORDER_PAID;
+import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_ORDER_REFUNDED;
+import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_ORDER_STOCK_RESTORED;
+
+import com.example.dropshop.domain.order.enums.OrderStatus;
+import com.example.dropshop.domain.order.event.OrderStatusChangedEvent;
+import com.example.dropshop.domain.order.event.StockRestoreEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 주문 도메인 이벤트를 Kafka로 발행한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class OrderEventProducer {
+
+  private final KafkaTemplate<String, OrderStatusChangedEvent> orderEventKafkaTemplate;
+  private final KafkaTemplate<String, StockRestoreEvent> orderStockRestoreKafkaTemplate;
+
+  /**
+   * 주문 상태 변경 이벤트를 상태별 토픽으로 전송한다.
+   */
+  public void sendStatusChanged(OrderStatusChangedEvent event) {
+    orderEventKafkaTemplate.send(resolveStatusTopic(event), event.eventKey(), event);
+  }
+
+  /**
+   * 주문 재고 복원 이벤트를 전송한다.
+   */
+  public void sendStockRestored(StockRestoreEvent event) {
+    orderStockRestoreKafkaTemplate.send(TOPIC_ORDER_STOCK_RESTORED, event.eventKey(), event);
+  }
+
+  private String resolveStatusTopic(OrderStatusChangedEvent event) {
+    if (event.getOrderStatus() == OrderStatus.PAID) {
+      return TOPIC_ORDER_PAID;
+    }
+    if (event.getOrderStatus() == OrderStatus.CANCELLED) {
+      return TOPIC_ORDER_CANCELLED;
+    }
+    return TOPIC_ORDER_REFUNDED;
+  }
+}

--- a/src/main/java/com/example/dropshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/dropshop/domain/order/service/OrderService.java
@@ -6,6 +6,7 @@ import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.order.entity.OrderItem;
 import com.example.dropshop.domain.order.enums.OrderStatus;
+import com.example.dropshop.domain.order.event.OrderStatusChangedEvent;
 import com.example.dropshop.domain.order.event.StockRestoreEvent;
 import com.example.dropshop.domain.order.exception.OrderException;
 import com.example.dropshop.domain.order.repository.OrderRepository;
@@ -27,6 +28,12 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Service
 @RequiredArgsConstructor
 public class OrderService {
+
+  private static final String SOURCE_MANUAL_CANCEL = "MANUAL_CANCEL";
+  private static final String SOURCE_EXPIRED_SCHEDULER = "EXPIRED_SCHEDULER";
+  private static final String SOURCE_PAYMENT_FAILURE = "PAYMENT_FAILURE";
+  private static final String SOURCE_PAYMENT_COMPLETED = "PAYMENT_COMPLETED";
+  private static final String SOURCE_REFUND_COMPLETED = "REFUND_COMPLETED";
 
   private final OrderRepository orderRepository;
   private final ApplicationEventPublisher eventPublisher;
@@ -111,6 +118,7 @@ public class OrderService {
     order.getOrderItems().forEach(item ->
         popularProductRedisService.incrementScore(item.getProductId(), item.getQuantity())
     );
+    publishOrderStatusChanged(order, SOURCE_PAYMENT_COMPLETED);
     return order;
   }
 
@@ -123,7 +131,8 @@ public class OrderService {
   @Transactional
   public Order refundOrder(Order order) {
     order.refund();
-    restoreDropStock(order);
+    publishOrderStatusChanged(order, SOURCE_REFUND_COMPLETED);
+    restoreDropStock(order, SOURCE_REFUND_COMPLETED);
     return order;
   }
 
@@ -132,8 +141,13 @@ public class OrderService {
    */
   @Transactional
   public Order cancelOrderAndRestoreStock(Order order) {
+    return cancelOrderAndRestoreStock(order, SOURCE_PAYMENT_FAILURE);
+  }
+
+  private Order cancelOrderAndRestoreStock(Order order, String source) {
     order.cancel();
-    restoreDropStock(order);
+    publishOrderStatusChanged(order, source);
+    restoreDropStock(order, source);
     return order;
   }
 
@@ -149,17 +163,23 @@ public class OrderService {
         .forEach(this::cancelExpiredOrderSafely);
   }
 
-  private void restoreDropStock(Order order) {
+  private void restoreDropStock(Order order, String source) {
     int restoreQuantity = order.getOrderItems().stream()
         .mapToInt(OrderItem::getQuantity)
         .sum();
-    eventPublisher.publishEvent(new StockRestoreEvent(order.getDropId(), restoreQuantity));
+    eventPublisher.publishEvent(new StockRestoreEvent(
+        order.getId(),
+        order.getDropId(),
+        restoreQuantity,
+        order.getStatus(),
+        source
+    ));
   }
 
   private Order cancelOrderInternal(Long orderId, Long userId) {
     Order order = orderRepository.findByIdAndUserId(orderId, userId)
         .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
-    return cancelOrderAndRestoreStock(order);
+    return cancelOrderAndRestoreStock(order, SOURCE_MANUAL_CANCEL);
   }
 
   private void cancelExpiredOrderSafely(Long orderId) {
@@ -180,7 +200,11 @@ public class OrderService {
       return;
     }
 
-    cancelOrderAndRestoreStock(order);
+    cancelOrderAndRestoreStock(order, SOURCE_EXPIRED_SCHEDULER);
+  }
+
+  private void publishOrderStatusChanged(Order order, String source) {
+    eventPublisher.publishEvent(new OrderStatusChangedEvent(order, source));
   }
 
 }

--- a/src/main/java/com/example/dropshop/domain/queue/listener/ReadyQueueTokenListener.java
+++ b/src/main/java/com/example/dropshop/domain/queue/listener/ReadyQueueTokenListener.java
@@ -3,20 +3,20 @@ package com.example.dropshop.domain.queue.listener;
 import static com.example.dropshop.common.constant.kafka.group.KafkaGroups.READY_QUEUE_GROUP_NAME;
 import static com.example.dropshop.common.constant.kafka.topic.KafkaTopics.TOPIC_READY_QUEUE_TOKEN;
 
-import com.example.dropshop.common.exception.ErrorCode;
-import com.example.dropshop.common.exception.ServiceException;
 import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
 import com.example.dropshop.domain.queue.entity.Queue;
 import com.example.dropshop.domain.queue.entity.QueueToken;
 import com.example.dropshop.domain.queue.repository.QueueRepository;
 import com.example.dropshop.domain.queue.repository.QueueTokenRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 /**
  * 준비된 대기열 토큰 리스너.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReadyQueueTokenListener {
@@ -25,18 +25,36 @@ public class ReadyQueueTokenListener {
 
   private final QueueRepository queueRepository;
 
+  /**
+   * 준비된 대기열 토큰 만료를 처리한다.
+   *
+   * <p>이미 토큰이나 큐가 정리된 경우도 있으므로, 오래된 메시지는 경고만 남기고 건너뛴다.
+   *
+   * @param threadHoldResponse 준비 완료된 대기열 응답
+   */
   @KafkaListener(
       topics = TOPIC_READY_QUEUE_TOKEN,
       groupId = READY_QUEUE_GROUP_NAME,
       containerFactory = "readyThreadHoldKafkaListenerContainerFactory"
   )
   public void consume(ThreadHoldResponse threadHoldResponse) {
-    QueueToken token = queueTokenRepository.findByQueueId(threadHoldResponse.getQueueId()).get();
+    QueueToken token = queueTokenRepository.findByQueueId(threadHoldResponse.getQueueId())
+        .orElse(null);
 
-    Queue queue = queueRepository.findByQueue(token).get();
+    if (token == null) {
+      log.warn("ready queue token not found. queueId={}", threadHoldResponse.getQueueId());
+      return;
+    }
+
+    Queue queue = queueRepository.findByQueue(token).orElse(null);
+
+    if (queue == null) {
+      log.warn("ready queue not found. queueId={}, tokenId={}",
+          threadHoldResponse.getQueueId(), token.getId());
+      return;
+    }
 
     queue.expire();
-
     queueRepository.save(queue);
   }
 }

--- a/src/test/java/com/example/dropshop/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/order/service/OrderServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 
 import com.example.dropshop.common.lock.LockKeys;
 import com.example.dropshop.common.lock.RedisLockService;
+import com.example.dropshop.domain.order.event.OrderStatusChangedEvent;
 import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.order.entity.OrderItem;
 import com.example.dropshop.domain.order.enums.OrderStatus;
@@ -182,10 +183,17 @@ class OrderServiceTest {
 
     assertThat(expiredOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 
-    ArgumentCaptor<StockRestoreEvent> eventCaptor =
-        ArgumentCaptor.forClass(StockRestoreEvent.class);
-    verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-    assertThat(eventCaptor.getValue().getDropId()).isEqualTo(dropId);
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
+    List<Object> events = eventCaptor.getAllValues();
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(OrderStatusChangedEvent.class);
+      assertThat(((OrderStatusChangedEvent) event).getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+    });
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(StockRestoreEvent.class);
+      assertThat(((StockRestoreEvent) event).getDropId()).isEqualTo(dropId);
+    });
   }
 
   @Test
@@ -223,10 +231,17 @@ class OrderServiceTest {
 
     assertThat(result.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 
-    ArgumentCaptor<StockRestoreEvent> eventCaptor =
-        ArgumentCaptor.forClass(StockRestoreEvent.class);
-    verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-    assertThat(eventCaptor.getValue().getQuantity()).isEqualTo(1);
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
+    List<Object> events = eventCaptor.getAllValues();
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(OrderStatusChangedEvent.class);
+      assertThat(((OrderStatusChangedEvent) event).getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+    });
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(StockRestoreEvent.class);
+      assertThat(((StockRestoreEvent) event).getQuantity()).isEqualTo(1);
+    });
     verify(redisLockService).executeWithLock(eq(LockKeys.order(1L)), any());
   }
 
@@ -266,10 +281,32 @@ class OrderServiceTest {
 
     assertThat(result.getStatus()).isEqualTo(OrderStatus.REFUNDED);
 
-    ArgumentCaptor<StockRestoreEvent> eventCaptor =
-        ArgumentCaptor.forClass(StockRestoreEvent.class);
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
+    List<Object> events = eventCaptor.getAllValues();
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(OrderStatusChangedEvent.class);
+      assertThat(((OrderStatusChangedEvent) event).getOrderStatus()).isEqualTo(OrderStatus.REFUNDED);
+    });
+    assertThat(events).anySatisfy(event -> {
+      assertThat(event).isInstanceOf(StockRestoreEvent.class);
+      assertThat(((StockRestoreEvent) event).getQuantity()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  @DisplayName("결제 완료 시 주문 상태 변경 이벤트가 발행된다")
+  void payOrder_success() {
+    Order order = createPendingOrder();
+
+    Order result = orderService.payOrder(order);
+
+    assertThat(result.getStatus()).isEqualTo(OrderStatus.PAID);
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
     verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-    assertThat(eventCaptor.getValue().getQuantity()).isEqualTo(1);
+    assertThat(eventCaptor.getValue()).isInstanceOf(OrderStatusChangedEvent.class);
+    assertThat(((OrderStatusChangedEvent) eventCaptor.getValue()).getOrderStatus())
+        .isEqualTo(OrderStatus.PAID);
   }
 
   @Test

--- a/src/test/java/com/example/dropshop/domain/queue/listener/ReadyQueueTokenListenerTest.java
+++ b/src/test/java/com/example/dropshop/domain/queue/listener/ReadyQueueTokenListenerTest.java
@@ -1,0 +1,71 @@
+package com.example.dropshop.domain.queue.listener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.dropshop.domain.queue.dto.response.ThreadHoldResponse;
+import com.example.dropshop.domain.queue.entity.Queue;
+import com.example.dropshop.domain.queue.entity.QueueToken;
+import com.example.dropshop.domain.queue.repository.QueueRepository;
+import com.example.dropshop.domain.queue.repository.QueueTokenRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReadyQueueTokenListenerTest {
+
+  @Mock
+  private QueueTokenRepository queueTokenRepository;
+
+  @Mock
+  private QueueRepository queueRepository;
+
+  @InjectMocks
+  private ReadyQueueTokenListener readyQueueTokenListener;
+
+  @Test
+  void 큐토큰이_없으면_예외없이_건너뛴다() {
+    ThreadHoldResponse response = ThreadHoldResponse.expire(1L, 10L);
+
+    when(queueTokenRepository.findByQueueId(10L)).thenReturn(Optional.empty());
+
+    readyQueueTokenListener.consume(response);
+
+    verify(queueRepository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void 큐가_없으면_예외없이_건너뛴다() {
+    ThreadHoldResponse response = ThreadHoldResponse.expire(1L, 10L);
+    QueueToken token = mock(QueueToken.class);
+
+    when(token.getId()).thenReturn(99L);
+    when(queueTokenRepository.findByQueueId(10L)).thenReturn(Optional.of(token));
+    when(queueRepository.findByQueue(token)).thenReturn(Optional.empty());
+
+    readyQueueTokenListener.consume(response);
+
+    verify(queueRepository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void 큐가_있으면_만료처리한다() {
+    ThreadHoldResponse response = ThreadHoldResponse.expire(1L, 10L);
+    Queue queue = new Queue(1L, 1L);
+    QueueToken token = new QueueToken("token", queue);
+
+    when(queueTokenRepository.findByQueueId(10L)).thenReturn(Optional.of(token));
+    when(queueRepository.findByQueue(token)).thenReturn(Optional.of(queue));
+
+    readyQueueTokenListener.consume(response);
+
+    verify(queueRepository).save(queue);
+  }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 결제/주문 이벤트 Kafka 발행 추가

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

## 작업 내용

결제와 주문 도메인에 Kafka 이벤트 발행을 추가했습니다.

- 결제 상태 변경 시 Kafka 이벤트 발행
  - `payment.completed`
  - `payment.failed`
- 주문 상태 변경 시 Kafka 이벤트 발행
  - `order.paid`
  - `order.cancelled`
  - `order.refunded`
  - `order.stock-restored`

## 변경 사항

- Payment
  - 결제 완료/실패 시 `PaymentStatusChangedEvent` 발행
  - `@TransactionalEventListener(AFTER_COMMIT)`로 커밋 이후 Kafka 전송
  - confirm API / webhook 중복 처리 시 멱등성 유지

- Order
  - 주문 결제 완료, 취소, 환불 완료 시 `OrderStatusChangedEvent` 발행
  - 재고 복원 시 `StockRestoreEvent` Kafka 전송 추가
  - 상태 변경 source 정보 포함

- Kafka
  - Producer / Listener / Topic 상수 추가
  - 관련 토픽 생성 및 연결 설정 반영



---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #12
- close #15

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항

- `payment.completed` 메시지 발행 확인
- `order.paid` 메시지 발행 확인
- Kafka consumer group 연결 및 lag 0 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 결제, 취소, 환불 상태 변경에 대한 이벤트 추적 기능 추가
  * 사용자 로그인 이벤트 추적 기능 추가
  * 재고 복구 이벤트 추적 기능 추가

* **버그 수정**
  * 대기열 시스템의 누락된 데이터 처리 안정성 개선

* **테스트**
  * 주문 상태 변경 및 환불 시나리오에 대한 테스트 추가
  * 대기열 처리 오류 케이스에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->