### PR TITLE
feat: drops 조회수 기능 추가

### DIFF
--- a/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
+++ b/src/main/java/com/example/dropshop/domain/drops/controller/DropsQueryController.java
@@ -5,12 +5,14 @@ import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
 import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.service.DropsQueryService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,10 +57,19 @@ public class DropsQueryController {
    */
   @GetMapping("/{dropId}")
   public ResponseEntity<ApiResponse<DropResponse>> getDropDetail(
-      @PathVariable Long dropId
+      @AuthenticationPrincipal String userEmail,
+      @PathVariable Long dropId,
+      HttpServletRequest request
   ) {
-    DropResponse response = dropsQueryService.findPublicDropDetail(dropId);
+    String clientIp = extractClientIp(request);
+    String userAgent = request.getHeader("User-Agent");
+    DropResponse response = dropsQueryService.findPublicDropDetail(dropId, userEmail, clientIp, userAgent);
     return ResponseEntity.ok(ApiResponse.ok(response));
+  }
+
+  private String extractClientIp(HttpServletRequest request) {
+    // 조회수 식별은 위조 가능한 헤더보다 서버가 인지한 원격 주소를 우선 사용한다.
+    return request.getRemoteAddr();
   }
 
 }

--- a/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/response/DropListItemResponse.java
@@ -19,6 +19,7 @@ public class DropListItemResponse {
   private final String status;
   private final LocalDateTime startAt;
   private final LocalDateTime endAt;
+  private final Long viewCount;
   private final Long soldCount;
   private final Long remainStock;
   private final Long purchaseLimit;
@@ -36,6 +37,7 @@ public class DropListItemResponse {
         .status(drops.getStatus().name())
         .startAt(drops.getStartAt())
         .endAt(drops.getEndAt())
+        .viewCount(drops.getViewCount())
         .soldCount(drops.getTotalStock() - drops.getRemainStock())
         .remainStock(drops.getRemainStock())
         .purchaseLimit(drops.getPurchaseLimit())

--- a/src/main/java/com/example/dropshop/domain/drops/dto/response/DropResponse.java
+++ b/src/main/java/com/example/dropshop/domain/drops/dto/response/DropResponse.java
@@ -19,6 +19,7 @@ public class DropResponse {
   private final LocalDateTime endAt;
   private final Long totalStock;
   private final Long remainStock;
+  private final Long viewCount;
   private final Long purchaseLimit;
   private final boolean useQueue;
   private final LocalDateTime createdAt;
@@ -28,6 +29,13 @@ public class DropResponse {
    * 드랍 엔티티를 응답 DTO로 변환한다.
    */
   public static DropResponse from(Drops drops) {
+    return from(drops, drops.getViewCount());
+  }
+
+  /**
+   * 드랍 엔티티를 응답 DTO로 변환한다.
+   */
+  public static DropResponse from(Drops drops, Long viewCount) {
     return DropResponse.builder()
         .dropId(drops.getId())
         .productId(drops.getProduct().getId())
@@ -36,6 +44,7 @@ public class DropResponse {
         .endAt(drops.getEndAt())
         .totalStock(drops.getTotalStock())
         .remainStock(drops.getRemainStock())
+        .viewCount(viewCount)
         .purchaseLimit(drops.getPurchaseLimit())
         .useQueue(drops.isUseQueue())
         .createdAt(drops.getCreatedAt())

--- a/src/main/java/com/example/dropshop/domain/drops/entity/Drops.java
+++ b/src/main/java/com/example/dropshop/domain/drops/entity/Drops.java
@@ -61,6 +61,9 @@ public class Drops extends BaseEntity {
   @Column(name = "use_queue", nullable = false)
   private boolean useQueue;
 
+  @Column(name = "view_count", nullable = false)
+  private Long viewCount;
+
   @Version
   private Long version;
 
@@ -82,6 +85,7 @@ public class Drops extends BaseEntity {
     this.purchaseLimit = purchaseLimit;
     this.useQueue = useQueue;
     this.status = DropsStatus.SCHEDULED;
+    this.viewCount = 0L;
 
     validateDateRange(startAt, endAt);
     validateStock(totalStock, remainStock);
@@ -186,6 +190,13 @@ public class Drops extends BaseEntity {
     if (this.remainStock > this.totalStock) {
       throw new DropsException(ErrorCode.INVALID_DROP_REMAIN_STOCK);
     }
+  }
+
+  /**
+   * 조회수를 1 증가시킨다.
+   */
+  public void increaseViewCount() {
+    this.viewCount += 1;
   }
 
   private void validateDateRange(LocalDateTime startAt, LocalDateTime endAt) {

--- a/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
+++ b/src/main/java/com/example/dropshop/domain/drops/repository/DropsRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -92,4 +93,11 @@ public interface DropsRepository extends JpaRepository<Drops, Long> {
    * 특정 상품에 지정 상태의 드랍이 존재하는지 확인한다.
    */
   boolean existsByProductIdAndStatusIn(Long productId, Collection<DropsStatus> statuses);
+
+  /**
+   * 드랍 조회수를 원자적으로 1 증가시킨다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("update Drops d set d.viewCount = d.viewCount + 1 where d.id = :dropId")
+  int incrementViewCount(@Param("dropId") Long dropId);
 }

--- a/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
+++ b/src/main/java/com/example/dropshop/domain/drops/service/DropsQueryService.java
@@ -7,11 +7,19 @@ import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.exception.DropsException;
 import com.example.dropshop.domain.drops.repository.DropsRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Base64;
 import java.util.EnumSet;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +32,19 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class DropsQueryService {
 
   private static final Set<DropsStatus> PUBLIC_VISIBLE_STATUSES =
       DropsConstants.PUBLIC_VISIBLE_STATUSES;
+  private static final String DROP_VIEW_KEY_PREFIX = "drop:view";
 
   private final DropsRepository dropsRepository;
+  private final StringRedisTemplate stringRedisTemplate;
+
+  @Value("${dropshop.drops.view-count-ttl-seconds:600}")
+  private long viewCountTtlSeconds;
 
   /**
    * 공개 드롭 목록을 조회한다.
@@ -57,11 +71,82 @@ public class DropsQueryService {
    * - SCHEDULED, ACTIVE, FINISHED만 공개 조회 가능
    * - useQueue 여부 표시 (규칙 4번: 선착순 드롭 구분)
    */
-  public DropResponse findPublicDropDetail(Long dropId) {
+  @Transactional
+  public DropResponse findPublicDropDetail(Long dropId, String userEmail, String clientIp, String userAgent) {
     Drops drops = dropsRepository.findOneByIdAndStatusIn(dropId, PUBLIC_VISIBLE_STATUSES)
         .orElseThrow(() -> new DropsException(ErrorCode.DROP_NOT_FOUND));
 
-    return DropResponse.from(drops);
+    long responseViewCount = drops.getViewCount();
+    if (shouldIncreaseViewCount(dropId, userEmail, clientIp, userAgent)) {
+      responseViewCount += 1;
+    }
+
+    return DropResponse.from(drops, responseViewCount);
+  }
+
+  private boolean shouldIncreaseViewCount(Long dropId, String userEmail, String clientIp, String userAgent) {
+    String viewIdentifier;
+    if (userEmail != null && !userEmail.isBlank()) {
+      viewIdentifier = userEmail;
+    } else if (clientIp != null && !clientIp.isBlank()) {
+      viewIdentifier = generateGuestIdentifier(clientIp, userAgent);
+    } else {
+      return false;
+    }
+
+    String viewKey = DROP_VIEW_KEY_PREFIX + ":" + dropId + ":" + viewIdentifier;
+
+    Boolean firstView;
+    try {
+      firstView = stringRedisTemplate.opsForValue().setIfAbsent(
+          viewKey,
+          "1",
+          Duration.ofSeconds(viewCountTtlSeconds)
+      );
+    } catch (Exception e) {
+      log.warn("조회수 중복 방지 키 처리 실패. dropId={}, userEmail={}", dropId, userEmail, e);
+      return false;
+    }
+
+    if (!Boolean.TRUE.equals(firstView)) {
+      return false;
+    }
+
+    try {
+      int updated = dropsRepository.incrementViewCount(dropId);
+      if (updated <= 0) {
+        rollbackViewKey(viewKey);
+        return false;
+      }
+      return true;
+    } catch (Exception e) {
+      rollbackViewKey(viewKey);
+      log.warn("조회수 증가 처리 실패. dropId={}, userEmail={}", dropId, userEmail, e);
+      return false;
+    }
+  }
+
+  private void rollbackViewKey(String viewKey) {
+    try {
+      stringRedisTemplate.delete(viewKey);
+    } catch (Exception e) {
+      log.warn("조회수 키 롤백 실패. viewKey={}", viewKey, e);
+    }
+  }
+
+  private String generateGuestIdentifier(String clientIp, String userAgent) {
+    String combined = clientIp + "|" + (userAgent != null ? userAgent : "");
+    MessageDigest md = getSha256Digest();
+    byte[] hash = md.digest(combined.getBytes(StandardCharsets.UTF_8));
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+  }
+
+  private MessageDigest getSha256Digest() {
+    try {
+      return MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm is not available", e);
+    }
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,8 @@ dropshop:
   product:
     max-image-count: 5
     purchasable-block-hours: 24
+  drops:
+    view-count-ttl-seconds: 600
 
 logging:
   level:

--- a/src/main/resources/db/migration/V12__add_drops_view_count.sql
+++ b/src/main/resources/db/migration/V12__add_drops_view_count.sql
@@ -1,0 +1,3 @@
+ALTER TABLE drops
+    ADD COLUMN view_count BIGINT NOT NULL DEFAULT 0;
+

--- a/src/test/java/com/example/dropshop/domain/drops/controller/DropsQueryControllerTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/controller/DropsQueryControllerTest.java
@@ -2,6 +2,7 @@ package com.example.dropshop.domain.drops.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -83,16 +84,18 @@ class DropsQueryControllerTest {
         .endAt(LocalDateTime.of(2026, 4, 26, 12, 0))
         .totalStock(30L)
         .remainStock(25L)
+        .viewCount(10L)
         .purchaseLimit(1L)
         .useQueue(true)
         .build();
 
-    given(dropsQueryService.findPublicDropDetail(10L)).willReturn(response);
+    given(dropsQueryService.findPublicDropDetail(eq(10L), isNull(), any(), any())).willReturn(response);
 
     mockMvc.perform(get("/api/drops/{dropId}", 10L))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.data.dropId").value(10L))
+        .andExpect(jsonPath("$.data.viewCount").value(10L))
         .andExpect(jsonPath("$.data.useQueue").value(true));
   }
 }

--- a/src/test/java/com/example/dropshop/domain/drops/service/DropsQueryServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/drops/service/DropsQueryServiceTest.java
@@ -2,20 +2,28 @@ package com.example.dropshop.domain.drops.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.BDDMockito.given;
 
 import com.example.dropshop.domain.drops.dto.response.DropListItemResponse;
+import com.example.dropshop.domain.drops.dto.response.DropResponse;
 import com.example.dropshop.domain.drops.entity.Drops;
 import com.example.dropshop.domain.drops.enums.DropsStatus;
 import com.example.dropshop.domain.drops.repository.DropsRepository;
 import com.example.dropshop.domain.product.entity.Product;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,6 +31,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +40,12 @@ class DropsQueryServiceTest {
 
   @Mock
   private DropsRepository dropsRepository;
+
+  @Mock
+  private StringRedisTemplate stringRedisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
 
   @InjectMocks
   private DropsQueryService dropsQueryService;
@@ -88,6 +104,136 @@ class DropsQueryServiceTest {
     assertThat(result.getContent().get(0).getStatus()).isEqualTo("FINISHED");
   }
 
+  @Test
+  @DisplayName("드롭 상세 조회 시 TTL 내 중복 조회가 아니면 조회수가 1 증가한다")
+  void findPublicDropDetail_increaseViewCountOnFirstView() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(true);
+    given(dropsRepository.incrementViewCount(10L)).willReturn(1);
+
+    DropResponse result = dropsQueryService.findPublicDropDetail(10L, "user@test.com", "127.0.0.1", "Mozilla/5.0");
+
+    assertThat(result.getViewCount()).isEqualTo(1L);
+    verify(dropsRepository).incrementViewCount(10L);
+    verify(stringRedisTemplate, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("드롭 상세 조회 시 TTL 내 중복 조회면 조회수가 증가하지 않는다")
+  void findPublicDropDetail_skipViewCountOnDuplicateView() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(false);
+
+    DropResponse result = dropsQueryService.findPublicDropDetail(10L, "user@test.com", "127.0.0.1", "Mozilla/5.0");
+
+    assertThat(result.getViewCount()).isEqualTo(0L);
+    verify(dropsRepository, never()).incrementViewCount(10L);
+    verify(stringRedisTemplate, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("조회수 DB 증가가 실패하면 선점한 Redis 키를 롤백한다")
+  void findPublicDropDetail_rollbackViewKeyWhenIncrementUpdatedZero() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(true);
+    given(dropsRepository.incrementViewCount(10L)).willReturn(0);
+
+    DropResponse result = dropsQueryService.findPublicDropDetail(10L, "user@test.com", "127.0.0.1", "Mozilla/5.0");
+
+    assertThat(result.getViewCount()).isEqualTo(0L);
+    verify(stringRedisTemplate).delete(any());
+  }
+
+  @Test
+  @DisplayName("조회수 DB 증가 중 예외가 발생하면 선점한 Redis 키를 롤백한다")
+  void findPublicDropDetail_rollbackViewKeyWhenIncrementThrows() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(true);
+    given(dropsRepository.incrementViewCount(10L)).willThrow(new RuntimeException("db failure"));
+
+    DropResponse result = dropsQueryService.findPublicDropDetail(10L, "user@test.com", "127.0.0.1", "Mozilla/5.0");
+
+    assertThat(result.getViewCount()).isEqualTo(0L);
+    verify(stringRedisTemplate).delete(any());
+  }
+
+  @Test
+  @DisplayName("비로그인 사용자 조회수 증가 - IP+UA 해시로 식별")
+  void findPublicDropDetail_increaseViewCountForGuestUser() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(true);
+    given(dropsRepository.incrementViewCount(10L)).willReturn(1);
+
+    DropResponse result = dropsQueryService.findPublicDropDetail(10L, null, "192.168.1.100", "Chrome/User-Agent");
+
+    assertThat(result.getViewCount()).isEqualTo(1L);
+    verify(dropsRepository).incrementViewCount(10L);
+
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).setIfAbsent(keyCaptor.capture(), eq("1"), any(Duration.class));
+    assertThat(keyCaptor.getValue()).startsWith("drop:view:10:");
+    assertThat(keyCaptor.getValue()).doesNotContain("+").doesNotContain("/").doesNotContain("=");
+  }
+
+  @Test
+  @DisplayName("비로그인 사용자 키는 IP가 다르면 다르게 생성된다")
+  void findPublicDropDetail_differentGuestUserIncreasesViewCount() {
+    Product product = createProduct(1L);
+    Drops drop = createDrop(product, DropsStatus.ACTIVE);
+
+    ReflectionTestUtils.setField(dropsQueryService, "viewCountTtlSeconds", 600L);
+
+    given(dropsRepository.findOneByIdAndStatusIn(eq(10L), any())).willReturn(Optional.of(drop));
+    given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), eq("1"), any(Duration.class)))
+        .willReturn(true);
+    given(dropsRepository.incrementViewCount(10L)).willReturn(1);
+
+    dropsQueryService.findPublicDropDetail(10L, null, "203.0.113.50", "Safari/User-Agent");
+    dropsQueryService.findPublicDropDetail(10L, null, "203.0.113.51", "Safari/User-Agent");
+
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations, times(2)).setIfAbsent(keyCaptor.capture(), eq("1"), any(Duration.class));
+    assertThat(keyCaptor.getAllValues().get(0)).isNotEqualTo(keyCaptor.getAllValues().get(1));
+    assertThat(keyCaptor.getAllValues().get(0)).startsWith("drop:view:10:");
+    assertThat(keyCaptor.getAllValues().get(1)).startsWith("drop:view:10:");
+  }
+
   private Product createProduct(Long sellerId) {
     Product product = Product.create(
         sellerId,
@@ -117,6 +263,7 @@ class DropsQueryServiceTest {
     );
     ReflectionTestUtils.setField(drops, "id", 10L);
     ReflectionTestUtils.setField(drops, "status", status);
+    ReflectionTestUtils.setField(drops, "viewCount", 0L);
     return drops;
   }
 }

--- a/src/test/java/com/example/dropshop/domain/product/service/ProductCommandServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/product/service/ProductCommandServiceTest.java
@@ -51,15 +51,15 @@ class ProductCommandServiceTest {
   void setUp() {
     productCommandService =
         new ProductCommandService(productRepository, productPolicyService, productValidator);
-
-    // 기본 정책값 mock 설정
-    given(productPolicyService.getDeliveryInfo()).willReturn("기본 배송 정책");
-    given(productPolicyService.getRefundPolicy()).willReturn("기본 환불 정책");
   }
 
   @Test
   @DisplayName("상품 생성 성공")
   void createSellerProduct_success() {
+    // 이 테스트에서만 사용되는 정책 스텁
+    given(productPolicyService.getDeliveryInfo()).willReturn("기본 배송 정책");
+    given(productPolicyService.getRefundPolicy()).willReturn("기본 환불 정책");
+
     ProductCreateRequest request = createProductCreateRequest();
 
     given(productRepository.save(any(Product.class))).willAnswer(invocation -> {


### PR DESCRIPTION
## 📌 PR 제목
feat: drops 조회수 기능 추가
---
## ✨ 변경 사항
- `Drops` 엔티티에 `view_count` 컬럼 추가 및 Flyway 마이그레이션(`V12`) 작성
- `DropsRepository`에 `@Modifying` 벌크 UPDATE 쿼리(`incrementViewCount`) 추가
- `DropsQueryService`에 Redis SET NX + TTL 기반 중복 조회수 방지 로직 구현
  - 로그인 사용자: 이메일 기반 식별
  - 비로그인 사용자: IP + User-Agent SHA-256 해시 기반 식별
  - Redis 선점 후 DB 업데이트 실패 시 Redis 키 롤백 처리
- `DropsQueryController`에서 `HttpServletRequest`로 클라이언트 IP 추출 (`getRemoteAddr()` 우선)
- `DropResponse`, `DropListItemResponse`에 `viewCount` 필드 추가
- `application.yml`에 `view-count-ttl-seconds` 설정값 추가 (기본값 600초)
---
## 🔗 관련 이슈
---
## 🧪 테스트
- [x] 최초 조회 시 조회수 1 증가 검증
- [x] TTL 내 중복 조회 시 조회수 증가 차단 검증
- [x] DB 업데이트 실패(`updated=0`) 시 Redis 키 롤백 검증
- [x] DB 업데이트 예외 발생 시 Redis 키 롤백 검증
- [x] 비로그인 사용자 IP+UA 해시로 조회수 증가 검증
- [x] IP가 다른 비로그인 사용자는 서로 다른 Redis 키 생성 검증
---
## 💡 참고 사항
- `X-Forwarded-For` 등 프록시 헤더는 클라이언트가 위조 가능하므로 `getRemoteAddr()`만 사용합니다. 로드밸런서 환경 도입 시 신뢰할 수 있는 헤더로 변경이 필요합니다.
- `@Modifying` 벌크 UPDATE는 JPA `@Version`(낙관적 락)을 갱신하지 않으므로, dirty checking 방식(`increaseViewCount()`)을 함께 사용하지 않도록 주의합니다.
- Redis 장애 시 조회수 증가를 skip하는 방향으로 처리하여 서비스 가용성을 우선합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 상품 조회수 추적 기능이 추가되었습니다.
  * Redis 기반 스마트 중복 조회 제외: 동일 사용자 또는 IP의 반복 조회는 조회수에 포함되지 않습니다.

* **Tests**
  * 조회수 추적 및 중복 제외 로직에 대한 테스트 커버리지 확대.

* **Chores**
  * 데이터베이스 마이그레이션 및 설정값 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->