### PR TITLE
feat: CD 배포 안정화 및 ElastiCache/RDS 운영 설정 반영

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -115,6 +115,8 @@ jobs:
           envs: APP_NAME,DEPLOY_DIR,MIN_DISK_MB
           script: |
             set -euo pipefail
+            trap 'echo "[deploy] failed at line $LINENO" >&2' ERR
+            set -x
             sudo mkdir -p "${DEPLOY_DIR}"
             sudo mv "/tmp/${APP_NAME}/docker-compose.prod.yml" "${DEPLOY_DIR}/docker-compose.yml"
             sudo mv "/tmp/${APP_NAME}/.env" "${DEPLOY_DIR}/.env"
@@ -127,7 +129,7 @@ jobs:
             "${DEPLOY_DIR}/scripts/ec2-preflight.sh" "${DEPLOY_DIR}" "${MIN_DISK_MB}"
 
             PREV_IMAGE=""
-            if docker ps -a --format '{{.Names}}' | grep -qx 'dropshop-app'; then
+            if docker container inspect dropshop-app >/dev/null 2>&1; then
               PREV_IMAGE="$(docker inspect --format='{{.Config.Image}}' dropshop-app || true)"
               echo "Detected previous image: ${PREV_IMAGE}"
             else
@@ -166,7 +168,7 @@ jobs:
               exit 1
             fi
 
-            APP_PORT=$(grep '^APP_PORT=' .env | cut -d '=' -f2)
+            APP_PORT="$(awk -F= '/^APP_PORT=/{print $2}' .env | tail -n1)"
             APP_PORT="${APP_PORT:-8080}"
             health_status=0
             for i in $(seq 1 12); do

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,7 @@ services:
     env_file:
       - .env
     depends_on:
+      # AWS ElastiCache 사용 시: redis 제거
       - redis
       - kafka-1
       - kafka-2
@@ -15,6 +16,11 @@ services:
     networks:
       - dropshop-net
 
+  # ============================================
+  # Redis 설정
+  # ============================================
+  # 옵션 1: 로컬 Docker Redis (개발/테스트)
+  # 아래 서비스 활성화
   redis:
     image: redis:7-alpine
     container_name: dropshop-redis
@@ -24,6 +30,16 @@ services:
       - redis_data:/data
     networks:
       - dropshop-net
+
+  # 옵션 2: AWS ElastiCache 사용 (프로덕션 권장)
+  # 1. 위 redis 서비스 제거
+  # 2. 위 app.depends_on에서 redis 제거
+  # 3. .env 파일에 다음 환경변수 설정:
+  #    REDIS_HOST=dropshop-redis.xxxx.cache.amazonaws.com
+  #    REDIS_PORT=6379
+  #    REDIS_PASSWORD={auth-token}
+  #    REDIS_USE_SSL=true
+  # 4. ELASTICACHE_SETUP.md 문서 참조
 
   kafka-1:
     image: bitnami/kafka:3.7

--- a/src/main/java/com/example/dropshop/common/config/S3PresignerConfig.java
+++ b/src/main/java/com/example/dropshop/common/config/S3PresignerConfig.java
@@ -3,22 +3,20 @@ package com.example.dropshop.common.config;
 import com.example.dropshop.domain.product.service.ProductImageUploadProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+/** S3 Presigner 빈 설정. */
 @Configuration
 public class S3PresignerConfig {
 
+  /** 기본 자격 증명 체인(IAM Role 포함)을 사용하는 S3 Presigner를 생성한다. */
   @Bean
-  public S3Presigner s3Presigner(
-      ProductImageUploadProperties imageProperties, AwsProperties awsProperties) {
-    AwsBasicCredentials credentials = AwsBasicCredentials.create("dummy", "dummy");
-
+  public S3Presigner s3Presigner(ProductImageUploadProperties imageProperties) {
     return S3Presigner.builder()
-        .region(Region.AP_NORTHEAST_2)
-        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .region(Region.of(imageProperties.getRegion()))
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
   }
 }

--- a/src/main/resources/application-local.yml.sample
+++ b/src/main/resources/application-local.yml.sample
@@ -31,6 +31,25 @@ product:
     cdn-base-url: https://YOUR_BUCKET.s3.ap-northeast-2.amazonaws.com
     presigned-expiration-seconds: 300
 
+spring:
+  cache:
+    type: redis
+    redis:
+      time-to-live: 3600000  # 1시간 (밀리초)
+      cache-null-values: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+      timeout: 60000ms
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 10
+          min-idle: 5
+          max-wait: -1ms
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,28 @@ spring:
     topic:
       partitions: ${SPRING_KAFKA_TOPIC_PARTITIONS:3}
       replication-factor: ${SPRING_KAFKA_TOPIC_REPLICATION_FACTOR:1}  # 운영에서는 2~3 권장
+  cache:
+    type: redis
+    redis:
+      time-to-live: 3600000  # 1시간 (밀리초)
+      cache-null-values: false
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      ssl:
+        enabled: ${REDIS_USE_SSL:true}
+      cluster:
+        nodes: ${SPRING_DATA_REDIS_CLUSTER_NODES:}
+      timeout: 60000ms
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 10
+          min-idle: 5
+          max-wait: -1ms
+        shutdown-timeout: 100ms
 
 # PortOne 설정
 portone:


### PR DESCRIPTION
## 📌 PR 제목
feat: CD 배포 안정화 및 ElastiCache/RDS 운영 설정 반영

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `.github/workflows/cd-ec2.yml`
  - 원격 배포 스크립트에 `trap`/`set -x` 추가로 실패 라인 추적 강화
  - `docker ps | grep` 대신 `docker container inspect` 사용으로 조기 종료 방지
  - `APP_PORT` 추출을 `awk` 기반으로 변경하여 `.env` 파싱 안정성 개선
  - 배포 실패 시 롤백 로직/헬스체크 흐름 정리
- `src/main/java/com/example/dropshop/common/config/S3PresignerConfig.java`
  - 정적 자격증명 제거, `DefaultCredentialsProvider` 적용(IAM Role 기반)
  - 리전 설정을 업로드 설정값 기반으로 사용
- `src/main/resources/application.yml`
  - Redis 설정에 `ssl.enabled` 및 `cluster.nodes` 환경변수 매핑 추가
    - `REDIS_USE_SSL`
    - `SPRING_DATA_REDIS_CLUSTER_NODES`
    - 
---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #<CD_이슈번호>
- close #<인프라_이슈번호>

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] `./gradlew compileJava` 통과
- [ ] EC2 CD 파이프라인 실배포 검증
- [ ] `/actuator/health` 200 응답 확인
- [ ] ElastiCache 연결 확인(TLS, cluster endpoint)

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
