### PR TITLE
fix : cd 실행 브랜치 dev > main 변경

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -2,7 +2,7 @@ name: CD-EC2-Docker
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["main"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -85,6 +85,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Add runner IP to EC2 security group
+        id: allow-runner-ip
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          SG_ID: ${{ secrets.EC2_SECURITY_GROUP_ID }}
+        run: |
+          RUNNER_IP=$(curl -sf https://checkip.amazonaws.com)
+          echo "runner_ip=${RUNNER_IP}" >> "$GITHUB_OUTPUT"
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${SG_ID}" \
+            --protocol tcp \
+            --port 22 \
+            --cidr "${RUNNER_IP}/32" \
+            --tag-specifications "ResourceType=security-group-rule,Tags=[{Key=CreatedBy,Value=github-actions},{Key=RunId,Value=${{ github.run_id }}}]"
+
       - name: Prepare production env file
         run: |
           printf '%s\n' "$PROD_ENV_FILE" > .env
@@ -204,4 +221,19 @@ jobs:
 
             docker image prune -af --filter "until=24h"
 
-
+      - name: Remove runner IP from EC2 security group
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          SG_ID: ${{ secrets.EC2_SECURITY_GROUP_ID }}
+        run: |
+          RUNNER_IP="${{ steps.allow-runner-ip.outputs.runner_ip }}"
+          if [ -n "${RUNNER_IP}" ]; then
+            aws ec2 revoke-security-group-ingress \
+              --group-id "${SG_ID}" \
+              --protocol tcp \
+              --port 22 \
+              --cidr "${RUNNER_IP}/32" || true
+          fi


### PR DESCRIPTION
## 📌 PR 제목
fix : cd 실행 브랜치 dev > main 변경

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- cd 실행 브랜치 dev -> main으로 수정
- CD 보안 강화: 배포 시 GitHub Actions runner IP를 EC2 보안 그룹에 동적으로 추가/제거하여 22번 포트 상시 노출 방지
---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.


---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 배포 및 인프라

* **Chores**
  * EC2 배포 워크플로우 트리거 설정이 업데이트되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3JOTEAM/dropshop/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->