### PR TITLE
fix: health check wget 실패 시 pipefail로 스크립트 중단되는 문제 수정

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -196,7 +196,7 @@ jobs:
             sleep 60
             health_status=0
             for i in $(seq 1 24); do
-              HEALTH=$(docker exec dropshop-app wget -qO- http://localhost:8080/actuator/health 2>/dev/null || true)
+              HEALTH="$(docker exec dropshop-app wget -qO- http://localhost:8080/actuator/health 2>&1)" || true
               if echo "${HEALTH}" | grep -q '"status":"UP"'; then
                 echo "Health check passed (attempt ${i})"
                 health_status=1


### PR DESCRIPTION
## 📌 PR 제목
fix: health check wget 실패 시 pipefail로 스크립트 중단되는 문제 수정

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- health check wget 실패 시 pipefail로 스크립트 중단되는 문제 수정

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #12
- close #15

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.