### PR TITLE
fix: healthcheck start_period 90s로 조정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 60
-      start_period: 30s
+      start_period: 90s
     networks:
       - dropshop-net
 


### PR DESCRIPTION
## 📌 PR 제목
fix: healthcheck start_period 90s로 조정

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- 앱 기동 시간(~50s)보다 충분히 긴 start_period를 설정해
기동 중 healthcheck 실패로 unhealthy 전환되는 문제 방지

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.

예)
- close #12
- close #15

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 애플리케이션 헬스체크 시작 지연 시간을 30초에서 90초로 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3JOTEAM/dropshop/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->