### PR TITLE
chore: CD 배포 실패 진단 로그 강화 및 health check 조기 실패 완화

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -171,6 +171,15 @@ jobs:
               fi
             }
 
+            dump_diagnostics() {
+              echo "===== deploy diagnostics ====="
+              docker compose --env-file .env -f docker-compose.yml ps || true
+              docker inspect --format='container_state={{json .State}}' dropshop-app || true
+              docker inspect --format='container_health={{json .State.Health}}' dropshop-app || true
+              docker logs --tail=300 dropshop-app || true
+              echo "===== end diagnostics ====="
+            }
+
             set +x
             printf '%s\n' "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
             set -x
@@ -188,29 +197,39 @@ jobs:
 
             if [ "${pull_status}" -ne 0 ] || [ "${up_status}" -ne 0 ]; then
               echo "Deployment failed (pull=${pull_status}, up=${up_status})."
+              dump_diagnostics
               rollback
               exit 1
             fi
 
             echo "Waiting for app to become healthy (up to 10m)..."
             health_status=0
+            unhealthy_streak=0
             for i in $(seq 1 60); do
               STATUS="$(docker inspect --format='{{.State.Health.Status}}' dropshop-app 2>/dev/null || echo 'unknown')"
               echo "Attempt ${i}/60: health=${STATUS}"
               if [ "${STATUS}" = "healthy" ]; then
                 echo "Health check passed (attempt ${i})"
                 health_status=1
+                unhealthy_streak=0
                 break
               fi
               if [ "${STATUS}" = "unhealthy" ]; then
-                echo "Container marked unhealthy, aborting early."
-                break
+                unhealthy_streak=$((unhealthy_streak + 1))
+                echo "Container unhealthy streak: ${unhealthy_streak}/3"
+                if [ "${unhealthy_streak}" -ge 3 ]; then
+                  echo "Container marked unhealthy 3 times, aborting."
+                  break
+                fi
+              else
+                unhealthy_streak=0
               fi
               sleep 10
             done
 
             if [ "${health_status}" -eq 0 ]; then
               echo "Health check failed after 600s."
+              dump_diagnostics
               rollback
               exit 1
             fi

--- a/src/main/java/com/example/dropshop/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/dropshop/domain/payment/service/PaymentService.java
@@ -133,8 +133,7 @@ public class PaymentService {
     // 이미 PortOne에 노출된 merchantPaymentId는 외부 웹훅/확정 응답 매핑에 사용되므로
     // 재시도 시에도 덮어쓰지 않고 기존 결제를 그대로 재사용한다.
     Optional<Payment> pendingPayment = paymentRepository.findByOrderId(orderId);
-    if (pendingPayment.isPresent()
-        && pendingPayment.get().getStatus() == PaymentStatus.PENDING) {
+    if (pendingPayment.isPresent() && pendingPayment.get().getStatus() == PaymentStatus.PENDING) {
       return validateIdempotentPreparedPayment(
           pendingPayment.get(), orderId, amount, paymentMethod);
     }

--- a/src/main/java/com/example/dropshop/domain/refund/service/RefundRecoveryService.java
+++ b/src/main/java/com/example/dropshop/domain/refund/service/RefundRecoveryService.java
@@ -3,7 +3,6 @@ package com.example.dropshop.domain.refund.service;
 import com.example.dropshop.common.exception.ErrorCode;
 import com.example.dropshop.common.lock.LockKeys;
 import com.example.dropshop.common.lock.RedisLockService;
-import com.example.dropshop.domain.order.entity.Order;
 import com.example.dropshop.domain.payment.client.PortOneClient;
 import com.example.dropshop.domain.payment.dto.response.PortOnePaymentResponse;
 import com.example.dropshop.domain.payment.entity.Payment;

--- a/src/test/java/com/example/dropshop/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/payment/service/PaymentServiceTest.java
@@ -161,7 +161,8 @@ class PaymentServiceTest {
   @DisplayName("결제 준비 재시도 - 같은 주문의 기존 PENDING 결제가 있으면 merchantPaymentId를 바꾸지 않고 재사용한다")
   void preparePayment_existingPendingPayment_reusesOriginalMerchantPaymentId() {
     given(orderFacadeService.findOrderForPayment(1L, "test@test.com")).willReturn(order);
-    given(paymentRepository.findByMerchantPaymentId("payment-retry-456")).willReturn(Optional.empty());
+    given(paymentRepository.findByMerchantPaymentId("payment-retry-456"))
+        .willReturn(Optional.empty());
     given(paymentRepository.findByOrderId(1L)).willReturn(Optional.of(payment));
 
     Payment result =

--- a/src/test/java/com/example/dropshop/domain/refund/service/RefundRecoveryServiceTest.java
+++ b/src/test/java/com/example/dropshop/domain/refund/service/RefundRecoveryServiceTest.java
@@ -94,7 +94,8 @@ class RefundRecoveryServiceTest {
     ReflectionTestUtils.setField(approvedRefund, "id", 1L);
     approvedRefund.approve();
 
-    given(refundRepository.findById(1L)).willReturn(Optional.of(refund), Optional.of(approvedRefund));
+    given(refundRepository.findById(1L))
+        .willReturn(Optional.of(refund), Optional.of(approvedRefund));
     given(paymentRepository.findById(1L)).willReturn(Optional.of(payment));
     given(portOneClient.getPayment("payment-test-123"))
         .willReturn(portOnePayment("PAID", "tx-123", "79000"));


### PR DESCRIPTION
## 📌 PR 제목
chore: CD 배포 실패 진단 로그 강화 및 health check 조기 실패 완화

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- `.github/workflows/cd-ec2.yml` 배포 스크립트 개선
  - `dump_diagnostics()` 함수 추가
    - `docker compose ps`
    - `dropshop-app`의 `.State`, `.State.Health`
    - `docker logs --tail=300 dropshop-app`
  - `docker compose pull/up` 실패 시 진단 로그 출력 후 rollback 수행
  - health check 실패 시에도 진단 로그 출력 후 rollback 수행
- health check 판정 로직 개선
  - 기존: `unhealthy` 1회 감지 시 즉시 실패
  - 변경: `unhealthy` 연속 3회일 때만 실패
  - 목적: 컨테이너 초기 기동 중 일시적 상태 변동으로 인한 오탐 실패 감소

---

## 🔗 관련 이슈
관련된 이슈 번호를 작성해주세요.



---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
리뷰어가 참고해야 할 사항이 있다면 작성해주세요.